### PR TITLE
update tc_1039 due to new behavior when run with bad proxy

### DIFF
--- a/tests/virtwho/tier1/tc_1039_check_http_proxy_option_by_etc_sysconfig.py
+++ b/tests/virtwho/tier1/tc_1039_check_http_proxy_option_by_etc_sysconfig.py
@@ -43,7 +43,7 @@ class Testcase(Testing):
             logger.info("> run virt-who with bad {0}".format(option))
             self.vw_option_update_value(option, bad_value, config_file)
             data, tty_output, rhsm_output = self.vw_start(exp_send=0)
-            s4 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+            s4 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             s5 = self.msg_validation(rhsm_output, error_msg, exp_exist=True)
             results.setdefault(step, []).append(s4)
             results.setdefault(step, []).append(s5)


### PR DESCRIPTION
In rhel8.1-beta, one more error is printed when run with bad proxy in /etc/sysconfig/virt-who, which error is already in msg list, so only changed error number to "1|2".