### PR TITLE
add rhel8 compose for updates build

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -901,6 +901,11 @@ class Provision(Register):
             rhel_release = compose_id.split('-')[0] + '-' + compose_id.split('-')[1]
             repo_base = "{0}/updates/{1}/{2}/compose/Server/x86_64/os".format(
                     base_url, rhel_release, compose_id)
+            if "RHEL-8" in compose_id:
+                repo_base = "{0}/updates/{1}/{2}/compose/BaseOS/x86_64/os".format(
+                    base_url, rhel_release, compose_id)
+                repo_optional = "{0}/updates/{1}/{2}/compose/AppStream/x86_64/os".format(
+                        base_url, rhel_release, compose_id)
             if "RHEL-7" in compose_id:
                 repo_optional = "{0}/updates/{1}/{2}/compose/Server-optional/x86_64/os".format(
                         base_url, rhel_release, compose_id)


### PR DESCRIPTION
There is no "RHEL-8" defined in function "rhel_compose_repo" when "updates" in compose_id, so add it to code.