### PR TITLE
Rhel compose url change

### DIFF
--- a/tests/tier1/tc_1001_check_virtwho_is_shipped_by_different_arch.py
+++ b/tests/tier1/tc_1001_check_virtwho_is_shipped_by_different_arch.py
@@ -20,11 +20,14 @@ class Testcase(Testing):
             raise FailException("virt-who pkg is not found")
         if compose_id is None or compose_id == "":
             raise FailException("compose_id is not defined")
+        rhel_url = "http://download.eng.bos.redhat.com"
+        rhel_release = compose_id.split('.')[0]
         if "updates" in compose_id:
-            rhel_release = compose_id.split('-')[0] + '-' + compose_id.split('-')[1]
-            baseurl = "http://download.eng.pek2.redhat.com/rel-eng/updates/{0}".format(rhel_release)
+            baseurl = "{0}/{1}/rel-eng/updates/{2}".format(
+                rhel_url, rhel_release.lower(), rhel_release)
         else:
-            baseurl = "http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7"
+            baseurl = "{0}/{1}/rel-eng/{2}".format(
+                rhel_url, rhel_release.lower(), rhel_release)
         if "RHEL-8" in compose_id:
             arch_list = ['x86_64', 'ppc64le', 'aarch64', 's390x']
         if "RHEL-7" in compose_id:
@@ -49,10 +52,11 @@ class Testcase(Testing):
         # case steps
         for arch in arch_list:
             if "RHEL-8" in compose_id:
-                baseurl = "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8"
-                pkg_url = "{0}/{1}/compose/AppStream/{2}/os/Packages/{3}".format(baseurl, compose_id, arch, pkg)
+                pkg_url = "{0}/{1}/compose/AppStream/{2}/os/Packages/{3}".format(
+                    baseurl, compose_id, arch, pkg)
             else:
-                pkg_url = "{0}/{1}/compose/{2}/os/Packages/{3}".format(baseurl, compose_id, arch, pkg)
+                pkg_url = "{0}/{1}/compose/{2}/os/Packages/{3}".format(
+                    baseurl, compose_id, arch, pkg)
             if self.url_validation(pkg_url):
                 results.setdefault('step1', []).append(True)
                 logger.info("{0} is exist in arch: {1}".format(pkg, arch))

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -899,30 +899,37 @@ class Provision(Register):
         base_url = deploy.repo.rhel
         if "updates" in compose_id:
             if "RHEL-8" in compose_id:
-                repo_base = "{0}/updates/RHEL-8/{1}/compose/BaseOS/x86_64/os".format(
+                repo_base = "{0}/rhel-8/rel-eng/updates/RHEL-8/{1}/compose/BaseOS/x86_64/os".format(
                     base_url, compose_id)
-                repo_optional = "{0}/updates/RHEL-8/{1}/compose/AppStream/x86_64/os".format(
+                repo_optional = "{0}/rhel-8/rel-eng/updates/RHEL-8/{1}/compose/AppStream/x86_64/os".format(
                     base_url, compose_id)
             if "RHEL-7" in compose_id:
-                repo_base = "{0}/updates/RHEL-7/{1}/compose/Server/x86_64/os".format(
+                repo_base = "{0}/rhel-7/rel-eng/updates/RHEL-7/{1}/compose/Server/x86_64/os".format(
                     base_url, compose_id)
-                repo_optional = "{0}/updates/RHEL-7/{1}/compose/Server-optional/x86_64/os".format(
+                repo_optional = "{0}/rhel-7/rel-eng/updates/RHEL-7/{1}/compose/Server-optional/x86_64/os".format(
                     base_url, compose_id)
             if "RHEL-6" in compose_id:
                 rhel_release = compose_id.split('-')[0] + '-' + compose_id.split('-')[1]
-                repo_base = "{0}/updates/{1}/{2}/compose/Server/x86_64/os".format(
+                repo_base = "{0}/rhel-6/rel-eng/updates/{1}/{2}/compose/Server/x86_64/os".format(
                     base_url, rhel_release, compose_id)
-                repo_optional = "{0}/updates/{1}/{2}/compose/Server/optional/x86_64/os".format(
+                repo_optional = "{0}/rhel-6/rel-eng/updates/{1}/{2}/compose/Server/optional/x86_64/os".format(
                         base_url, rhel_release, compose_id)
         else:
-            repo_base = "{0}/{1}/compose/Server/x86_64/os".format(base_url, compose_id)
             if "RHEL-8" in compose_id:
-                repo_base = "{0}/{1}/compose/BaseOS/x86_64/os".format(base_url, compose_id)
-                repo_optional = "{0}/{1}/compose/AppStream/x86_64/os".format(base_url, compose_id)
+                repo_base = "{0}/rhel-8/rel-eng/RHEL-8/{1}/compose/BaseOS/x86_64/os".format(
+                    base_url, compose_id)
+                repo_optional = "{0}/rhel-8/rel-eng/RHEL-8/{1}/compose/AppStream/x86_64/os".format(
+                    base_url, compose_id)
             if "RHEL-7" in compose_id:
-                repo_optional = "{0}/{1}/compose/Server-optional/x86_64/os".format(base_url, compose_id)
+                repo_base = "{0}/rhel-7/rel-eng/RHEL-7/{1}/compose/Server/x86_64/os".format(
+                    base_url, compose_id)
+                repo_optional = "{0}/rhel-7/rel-eng/RHEL-7/{1}/compose/Server-optional/x86_64/os".format(
+                    base_url, compose_id)
             if "RHEL-6" in compose_id:
-                repo_optional = "{0}/{1}/compose/Server/optional/x86_64/os/".format(base_url, compose_id)
+                repo_base = "{0}/rhel-6/rel-eng/{1}/compose/Server/x86_64/os".format(
+                    base_url, compose_id)
+                repo_optional = "{0}/rhel-6/rel-eng/{1}/compose/Server/optional/x86_64/os/".format(
+                    base_url, compose_id)
         cmd = ('cat <<EOF > {0}\n'
                '[{1}]\n'
                'name={1}\n'
@@ -1009,31 +1016,38 @@ class Provision(Register):
         ks_url= "{0}/{1}".format(nfs_rhel_url, ks_name)
         ks_path = "{0}/{1}".format(nfs_rhel_mount, ks_name)
         if "updates" in compose_id:
+            if "RHEL-8" in compose_id:
+                base_repo = "{0}/rhel-8/rel-eng/updates/RHEL-8/{1}/compose/BaseOS/x86_64/os".format(
+                    base_url, compose_id)
+                extra_repo = "{0}/rhel-8/rel-eng/updates/RHEL-8/{1}/compose/AppStream/x86_64/os".format(
+                    base_url, compose_id)
+            if "RHEL-7" in compose_id:
+                base_repo = "{0}/rhel-7/rel-eng/updates/RHEL-7/{1}/compose/Server/x86_64/os".format(
+                    base_url, compose_id)
+                extra_repo = "{0}/rhel-7/rel-eng/updates/RHEL-7/{1}/compose/Server-optional/x86_64/os".format(
+                    base_url, compose_id)
             if "RHEL-6" in compose_id:
                 rhel_release = compose_id.split('-')[0] + '-' + compose_id.split('-')[1]
-                base_repo = "{0}/updates/{1}/{2}/compose/Server/x86_64/os".format(
+                base_repo = "{0}/rhel-6/rel-eng/updates/{1}/{2}/compose/Server/x86_64/os".format(
                     base_url, rhel_release, compose_id)
-                extra_repo = "{0}/updates/{1}/{2}/compose/Server/optional/x86_64/os".format(
+                extra_repo = "{0}/rhel-6/rel-eng/updates/{1}/{2}/compose/Server/optional/x86_64/os".format(
                         base_url, rhel_release, compose_id)
-            if "RHEL-7" in compose_id:
-                base_repo = "{0}/updates/RHEL-7/{1}/compose/Server/x86_64/os".format(
-                    base_url, compose_id)
-                extra_repo = "{0}/updates/RHEL-7/{1}/compose/Server-optional/x86_64/os".format(
-                    base_url, compose_id)
-            if "RHEL-8" in compose_id:
-                base_repo = "{0}/updates/RHEL-8/{1}/compose/BaseOS/x86_64/os".format(
-                    base_url, compose_id)
-                extra_repo = "{0}/updates/RHEL-8/{1}/compose/AppStream/x86_64/os".format(
-                    base_url, compose_id)
         else:
-            base_repo = "{0}/{1}/compose/Server/x86_64/os".format(base_url, compose_id)
-            if "RHEL-6" in compose_id:
-                extra_repo = "{0}/{1}/compose/Server/optional/x86_64/os".format(base_url, compose_id)
-            if "RHEL-7" in compose_id:
-                extra_repo = "{0}/{1}/compose/Server-optional/x86_64/os".format(base_url, compose_id)
             if "RHEL-8" in compose_id:
-                base_repo = "{0}/{1}/compose/BaseOS/x86_64/os".format(base_url, compose_id)
-                extra_repo = "{0}/{1}/compose/AppStream/x86_64/os".format(base_url, compose_id)
+                base_repo = "{0}/rhel-8/rel-eng/RHEL-8/{1}/compose/BaseOS/x86_64/os".format(
+                    base_url, compose_id)
+                extra_repo = "{0}/rhel-8/rel-eng/RHEL-8/{1}/compose/AppStream/x86_64/os".format(
+                    base_url, compose_id)
+            if "RHEL-7" in compose_id:
+                base_repo = "{0}/rhel-7/rel-eng/RHEL-7/{1}/compose/Server/x86_64/os".format(
+                    base_url, compose_id)
+                extra_repo = "{0}/rhel-7/rel-eng/RHEL-7/{1}/compose/Server-optional/x86_64/os".format(
+                    base_url, compose_id)
+            if "RHEL-6" in compose_id:
+                base_repo = "{0}/rhel-6/rel-eng/{1}/compose/Server/x86_64/os".format(
+                    base_url, compose_id)
+                extra_repo = "{0}/rhel-6/rel-eng/{1}/compose/Server/optional/x86_64/os/".format(
+                    base_url, compose_id)
         cmd = ('cat <<EOF > {0}\n'
                'install\n'
                'lang en_US.UTF-8\n'


### PR DESCRIPTION
the old rhel path is disappeared, now changed to use "download.eng.bos.redhat.com", so updated two functions rhel_install_by_grub and rhel_compose_repo in provision.py for all rhel6, 7 and 8. 