### PR TITLE
Virtwho patch 20190729

### DIFF
--- a/tests/tier1/tc_1085_check_vdc_virtual_pool_attached_by_poolId_in_guest.py
+++ b/tests/tier1/tc_1085_check_vdc_virtual_pool_attached_by_poolId_in_guest.py
@@ -49,4 +49,9 @@ class Testcase(Testing):
         results.setdefault('step4', []).append(res)
 
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        server_type = self.get_config('register_type')
+        if 'stage' in server_type:
+            notes.append("Bug(Step*): Failed to synchronize cache for repo 'rhel-8-for-x86_64-baseos-rpms'")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1719177")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1099_check_instance_consumed_status_in_host_after_set_cpu_socket_8.py
+++ b/tests/tier1/tc_1099_check_instance_consumed_status_in_host_after_set_cpu_socket_8.py
@@ -86,4 +86,9 @@ class Testcase(Testing):
         self.system_custom_facts_remove(self.ssh_host())
 
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        server_type = self.get_config('register_type')
+        if 'stage' in server_type:
+            notes.append("Bug(Step6): SKU RH00003 has different consumer behaviors for servers")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1703336")
+        self.vw_case_result(results, notes)

--- a/tests/tier3/0_test.py
+++ b/tests/tier3/0_test.py
@@ -1,0 +1,8 @@
+type = 'https_proxy'
+hypervisor_type = 'libvirt'
+if (type == 'http_proxy' and 'hyperv' not in hypervisor_type) \
+        or (type == 'https_proxy' and hypervisor_type in ('kubevirt', 'libvirt', 'hyperv')):
+# if type == 'http_proxy':
+    print('true')
+else:
+    print('false')

--- a/tests/tier3/0_test.py
+++ b/tests/tier3/0_test.py
@@ -1,8 +1,0 @@
-type = 'https_proxy'
-hypervisor_type = 'libvirt'
-if (type == 'http_proxy' and 'hyperv' not in hypervisor_type) \
-        or (type == 'https_proxy' and hypervisor_type in ('kubevirt', 'libvirt', 'hyperv')):
-# if type == 'http_proxy':
-    print('true')
-else:
-    print('false')

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1,3 +1,5 @@
+import self as self
+
 from virt_who import *
 from virt_who.base import Base
 from virt_who.register import Register
@@ -1693,6 +1695,8 @@ class Provision(Register):
         # self.qa_enable_rhel_repo(ssh_libvirt)
         # self.libvirt_pkg_install(ssh_libvirt)
         # self.bridge_setup("br0", ssh_libvirt)
+        cmd = "service libvirtd restart"
+        ret, output = self.runcmd(cmd, ssh_libvirt)
         guest_ip = self.libvirt_guest_ip(guest_name, ssh_libvirt)
         if not guest_ip:
             self.libvirt_guests_all_clean(ssh_libvirt)


### PR DESCRIPTION
Updated some testcased and function.
1. tc_1085 and tc_1099: add bug info to test result.

2. tc_2048: remove test point "temporary sku should be changed to stable sku" because tc_1107 has covered it and add test point to check "guest can auto attach one temporary sku before run virt-who " and "guest can auto attach stable virtual sku after run virt-who".

3. guest_libvirt_remote_setup() function in provision.py: add step to restart libvirtd service when prepare libvirt-remote hypervisor.

