### PR TITLE
Rhsm conf backup patch

### DIFF
--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -15,10 +15,22 @@ class Testcase(Testing):
         # Case Config
         results = dict()
         sysconfig_file = "/etc/sysconfig/virt-who"
-        self.vw_option_enable('[global]', '/etc/virt-who.conf')
-        self.vw_option_enable('debug', '/etc/virt-who.conf')
-        self.vw_option_update_value('debug', 'True', '/etc/virt-who.conf')
+        vw_conf = "/etc/virt-who.conf"
+        self.vw_option_enable('[global]', vw_conf)
+        self.vw_option_enable('debug', vw_conf)
+        self.vw_option_update_value('debug', 'True', vw_conf)
+        self.vw_option_enable('[defaults]', vw_conf)
         self.vw_etc_d_mode_create('virtwho-config', '/etc/virt-who.d/virtwho-config.conf')
+        register_config = self.get_register_config()
+        register_server = register_config['server']
+        register_type = register_config['type']
+        if "satellite" in register_type:
+            ssh_sat = register_config['ssh_sat']
+            register_server = self.get_hostname(ssh_sat)
+        hypervisor_config = self.get_hypervisor_config()
+        hypervisor_server = hypervisor_config['ssh_hypervisor']['host']
+        if hypervisor_type == 'rhevm':
+            hypervisor_server = self.get_hostname(hypervisor_config['ssh_hypervisor'])
         good_squid_server = "10.73.3.248:3128"
         wrong_squid_server = "10.73.3.24:3128"
         types = {'type1':'http_proxy', 'type2':'https_proxy'}
@@ -26,7 +38,7 @@ class Testcase(Testing):
         # Case Steps
         logger.info(">>>step1: run with good proxy server")
         for type, option in sorted(types.items(), key=lambda item:item[0]):
-            logger.info(">>>%s: run virt-who to check %s" % (type, option))
+            logger.info(">>%s: run virt-who to check %s" % (type, option))
             if option == "http_proxy":
                 value = "http://{0}".format(good_squid_server)
             if option == "https_proxy":
@@ -41,9 +53,10 @@ class Testcase(Testing):
             results.setdefault('step1', []).append(res3)
             self.vw_option_del(option, filename=sysconfig_file)
 
-        logger.info(">>>step2: run with wrong proxy server and 'NO_PROXY'")
+        logger.info(">>>step2: run with bad proxy server and no_proxy")
         for type, option in sorted(types.items(), key=lambda item:item[0]):
-            logger.info(">>>%s: run virt-who to check %s with wrong proxy" % (type, option))
+            logger.info(">>%s: ------ %s test------" % (type, option))
+            logger.info("> run virt-who with bad {0}".format(option))
             if option == "http_proxy":
                 value = "http://{0}".format(wrong_squid_server)
             if option == "https_proxy":
@@ -51,20 +64,40 @@ class Testcase(Testing):
             self.vw_option_add(option, value, filename=sysconfig_file)
             data, tty_output, rhsm_output = self.vw_start(exp_send=0, exp_error=True)
             error_msg = "Connection refused|Cannot connect to proxy|Connection timed out"
-            res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+            res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, error_msg)
-            self.vw_option_add("NO_PROXY", "*", filename=sysconfig_file)
-            data, tty_output, rhsm_output = self.vw_start(exp_send=1)
-            res3 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+            logger.info("> configure no_proxy=[register_server] in /etc/sysconfig/virt-who")
+            self.vw_option_add("no_proxy", register_server, sysconfig_file)
+            if hypervisor_type in ('libvirt-remote', 'hyperv', 'kubevirt'):
+                logger.info("virt-who connect hypervisor '{0}' not by proxy".format(hypervisor_type))
+                data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+                res3 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+                res4 = res5 = "true"
+            else:
+                logger.info("virt-who connect hypervisor '{0}' by proxy".format(hypervisor_type))
+                error_msg = "Cannot connect to proxy"
+                data, tty_output, rhsm_output = self.vw_start(exp_send=0, exp_error=True)
+                res3 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
+                res4 = self.vw_msg_search(rhsm_output, error_msg)
+                logger.info("> Configure no_proxy=[hypervisor_server] and rhsm_no_proxy=[register_server]")
+                self.vw_option_update_value("no_proxy", hypervisor_server, sysconfig_file)
+                self.vw_option_enable("rhsm_no_proxy", vw_conf)
+                self.vw_option_update_value("rhsm_no_proxy", register_server, vw_conf)
+                data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+                res5 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step2', []).append(res1)
             results.setdefault('step2', []).append(res2)
             results.setdefault('step2', []).append(res3)
-            self.vw_option_del(option, filename=sysconfig_file)
-            self.vw_option_del("NO_PROXY", filename=sysconfig_file)
+            results.setdefault('step2', []).append(res4)
+            results.setdefault('step2', []).append(res5)
+            self.vw_option_del('no_proxy', sysconfig_file)
+            self.vw_option_del(option, sysconfig_file)
+            self.vw_option_disable('rhsm_no_proxy', vw_conf)
 
         # Case Result
+        logger.info("WONTFI bz1716337 - virt-who doesn't connect all hypervisors by proxy")
         notes = list()
-        if "hyperv" in hypervisor_type:
-            notes.append("Bug(Step1): hyperv doesn't support http_proxy")
-            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1638250")
+        if hypervisor_type == 'xen':
+            notes.append("(step2) [XEN] Succeeded to send mapping but always print errors")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1739358")
         self.vw_case_result(results, notes)

--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -62,14 +62,14 @@ class Testcase(Testing):
             error_msg = "Connection refused|Cannot connect to proxy|Connection timed out"
             res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, error_msg)
+            results.setdefault('step2', []).append(res1)
+            results.setdefault('step2', []).append(res2)
             logger.info("> configure no_proxy=[register_server] in /etc/sysconfig/virt-who")
             self.vw_option_add("no_proxy", register_server, sysconfig_file)
             if hypervisor_type in ('libvirt-remote', 'hyperv', 'kubevirt'):
                 logger.info("virt-who connect hypervisor '{0}' not by proxy".format(hypervisor_type))
                 data, tty_output, rhsm_output = self.vw_start(exp_send=1)
                 res3 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-                results.setdefault('step2', []).append(res1)
-                results.setdefault('step2', []).append(res2)
                 results.setdefault('step2', []).append(res3)
             else:
                 logger.info("virt-who connect hypervisor '{0}' by proxy".format(hypervisor_type))
@@ -83,8 +83,6 @@ class Testcase(Testing):
                 self.vw_option_update_value("rhsm_no_proxy", register_server, vw_conf)
                 data, tty_output, rhsm_output = self.vw_start(exp_send=1)
                 res5 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-                results.setdefault('step2', []).append(res1)
-                results.setdefault('step2', []).append(res2)
                 results.setdefault('step2', []).append(res3)
                 results.setdefault('step2', []).append(res4)
                 results.setdefault('step2', []).append(res5)

--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -23,10 +23,6 @@ class Testcase(Testing):
         self.vw_etc_d_mode_create('virtwho-config', '/etc/virt-who.d/virtwho-config.conf')
         register_config = self.get_register_config()
         register_server = register_config['server']
-        register_type = register_config['type']
-        if "satellite" in register_type:
-            ssh_sat = register_config['ssh_sat']
-            register_server = self.get_hostname(ssh_sat)
         hypervisor_config = self.get_hypervisor_config()
         hypervisor_server = hypervisor_config['ssh_hypervisor']['host']
         if hypervisor_type == 'rhevm':
@@ -72,7 +68,9 @@ class Testcase(Testing):
                 logger.info("virt-who connect hypervisor '{0}' not by proxy".format(hypervisor_type))
                 data, tty_output, rhsm_output = self.vw_start(exp_send=1)
                 res3 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-                res4 = res5 = "true"
+                results.setdefault('step2', []).append(res1)
+                results.setdefault('step2', []).append(res2)
+                results.setdefault('step2', []).append(res3)
             else:
                 logger.info("virt-who connect hypervisor '{0}' by proxy".format(hypervisor_type))
                 error_msg = "Cannot connect to proxy"
@@ -85,11 +83,11 @@ class Testcase(Testing):
                 self.vw_option_update_value("rhsm_no_proxy", register_server, vw_conf)
                 data, tty_output, rhsm_output = self.vw_start(exp_send=1)
                 res5 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-            results.setdefault('step2', []).append(res1)
-            results.setdefault('step2', []).append(res2)
-            results.setdefault('step2', []).append(res3)
-            results.setdefault('step2', []).append(res4)
-            results.setdefault('step2', []).append(res5)
+                results.setdefault('step2', []).append(res1)
+                results.setdefault('step2', []).append(res2)
+                results.setdefault('step2', []).append(res3)
+                results.setdefault('step2', []).append(res4)
+                results.setdefault('step2', []).append(res5)
             self.vw_option_del('no_proxy', sysconfig_file)
             self.vw_option_del(option, sysconfig_file)
             self.vw_option_disable('rhsm_no_proxy', vw_conf)

--- a/virt_who/base.py
+++ b/virt_who/base.py
@@ -381,6 +381,7 @@ class Base(unittest.TestCase):
 
     def system_init(self, key, ssh):
         if self.ssh_is_connected(ssh):
+            self.rhsm_backup(ssh)
             host_ip = self.get_ipaddr(ssh)
             host_name = self.get_hostname(ssh)
             if "localhost" in host_name or "unused" in host_name or "openshift" in host_name or host_name is None:

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1087,6 +1087,7 @@ class Provision(Register):
             if self.ssh_is_connected(ssh_host):
                 self.rhel_compose_repo(ssh_host, compose_id, "/etc/yum.repos.d/compose.repo")
                 self.install_base_packages(ssh_host)
+                self.rhsm_backup(ssh_host)
         except Exception, e:
             logger.error(e)
         finally:
@@ -1154,6 +1155,7 @@ class Provision(Register):
             initrd_url = "{0}/{1}/mnt/isolinux/initrd.img".format(nfs_rhev_url, random_dir)
             self.rhel_grub_update(ssh_host, ks_url, vmlinuz_url, initrd_url, repo_url, is_rhev=True)
             self.ssh_is_connected(ssh_host)
+            self.rhsm_backup(ssh_host)
         except Exception, e:
             logger.error(e)
         finally:
@@ -1430,6 +1432,7 @@ class Provision(Register):
                 'ssh_sat':ssh_sat
         }
         self.system_init("ci-host-satellite", ssh_sat)
+        self.rhsm_backup(ssh_sat)
         sat_ver, rhel_ver = self.satellite_version(sat_type)
         if "dogfood" in sat_type:
             self.satellite_qa_dogfood_enable(ssh_sat, sat_ver, rhel_ver, repo_type="satellite")
@@ -2083,7 +2086,7 @@ class Provision(Register):
 
     def hyperv_guest_ip(self, ssh_hyperv, guest_name):
         cmd = "powershell (Get-VMNetworkAdapter -VMName %s).IpAddresses" % (guest_name)
-        for i in range(60):
+        for i in range(20):
             time.sleep(30)
             ret, output = self.runcmd(cmd, ssh_hyperv)
             if ret == 0 and output != "":


### PR DESCRIPTION
1. Uptated tc_2013_validate_unreachable_proxy_by_config.py
* virt-who connect 'libvirt-remote', 'hyperv' and 'kubevirt' not by proxy
* virt-who connect 'xen', 'rhvm' and 'esx' by proxy.
* new bug for xen

2. Add self.rhsm_backup(ssh_host) after finish installing vdsm and satellite machine, because before we deploy them by registering to QualityAssurance,which will not edit rhsm.conf, so we can backup rhsm.conf at last together with all hosts and guests, but now we changed to use Employee Sku and Satellite Sku in Stage Candlepin, so it will change rhsm.log before we backup it, it will not be the origin file. So we backup it when just finished os install.