### PR TITLE
Patch rhel81 new feature

### DIFF
--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -4,10 +4,13 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136709')
         hypervisor_type = self.get_config('hypervisor_type')
+        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] < '0.25.7':
+            self.vw_case_skip("virt-who version")
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         self.vw_case_init()

--- a/tests/tier2/tc_2014_validate_header_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2014_validate_header_option_in_etc_virtwho_d.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136585')
@@ -21,6 +22,9 @@ class Testcase(Testing):
         config_name = "virtwho-config"
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
+        vw_pkg = self.pkg_check(self.ssh_host(), 'virt-who')
+        msg_list = ["no section headers|Error in .* backend|"
+                    "do not have any valid section headers"]
 
         # Case Steps
         logger.info(">>>step1: header option is good value")
@@ -29,36 +33,48 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: header option is space value")
-        logger.warning("Sapce value[ ] is acceptable for header option")
         self.vw_option_update_name(option_tested, "[ ]", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-        results.setdefault('step2', []).append(res1)
+        if vw_pkg[9:15] >= '0.25.7':
+            res1 = self.op_normal_value(data, exp_error=2, exp_thread=0, exp_send=0)
+            res2 = self.msg_validation(rhsm_output, msg_list)
+            results.setdefault('step2', []).append(res1)
+            results.setdefault('step2', []).append(res2)
+        else:
+            logger.warning("Sapce value[ ] is acceptable for header option")
+            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+            results.setdefault('step2', []).append(res1)
 
         logger.info(">>>step3: header option is 红帽€467aa value")
-        logger.warning("Special value is acceptable for header option")
+        logger.info("Special value is acceptable for header option")
         self.vw_option_update_name(option_tested, '[红帽€467aa]', config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step3', []).append(res1)
 
         logger.info(">>>step4: header option is null value")
-        logger.warning("libvirt-local mode will be used to instead when header option is null")
         self.vw_option_update_name(option_tested, '[]', config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["no section headers|Error in .* backend"]
-        res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
-        res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        if vw_pkg[9:15] >= '0.25.7':
+            res1 = self.op_normal_value(data, exp_error=3, exp_thread=0, exp_send=0)
+        else:
+            logger.warning(
+                "libvirt-local mode will be used to instead when header option is null")
+            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
+        res2 = self.msg_validation(rhsm_output, msg_list)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
 
         logger.info(">>>step5: header option is disable")
-        logger.warning("libvirt-local mode will be used to instead when header option is null")
         self.vw_option_disable(option_tested, config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["no section headers|Error in .* backend"]
-        res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
-        res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        if vw_pkg[9:15] >= '0.25.7':
+            res1 = self.op_normal_value(data, exp_error=3, exp_thread=0, exp_send=0)
+        else:
+            logger.warning(
+                "libvirt-local mode will be used when run without header option")
+            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
+        res2 = self.msg_validation(rhsm_output, msg_list)
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)
 
@@ -70,7 +86,7 @@ class Testcase(Testing):
         data, tty_output, rhsm_output = self.vw_start(exp_error=True)
         msg_list = ["no section headers"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=1)
-        res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        res2 = self.msg_validation(rhsm_output, msg_list)
         results.setdefault('step6', []).append(res1)
         results.setdefault('step6', []).append(res2)
 
@@ -80,7 +96,7 @@ class Testcase(Testing):
         data, tty_output, rhsm_output = self.vw_start(exp_error=True)
         msg_list = ["no section headers"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=1)
-        res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        res2 = self.msg_validation(rhsm_output, msg_list)
         results.setdefault('step7', []).append(res1)
         results.setdefault('step7', []).append(res2)
 

--- a/tests/tier2/tc_2014_validate_header_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2014_validate_header_option_in_etc_virtwho_d.py
@@ -23,7 +23,8 @@ class Testcase(Testing):
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
         vw_pkg = self.pkg_check(self.ssh_host(), 'virt-who')
-        msg_list = ["no section headers|Error in .* backend|"
+        msg_list = ["no section headers|"
+                    "Error in .* backend|"
                     "do not have any valid section headers"]
 
         # Case Steps

--- a/tests/tier2/tc_2016_validate_owner_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2016_validate_owner_option_in_etc_virtwho_d.py
@@ -32,7 +32,8 @@ class Testcase(Testing):
         logger.info(">>>step2: owner option is wrong value")
         self.vw_option_update_value(option_tested, "xxxxxx", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["owner.* is different|Communication with subscription manager failed"]
+        msg_list = ["owner.* is different|"
+                    "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step2', []).append(res1)
@@ -48,7 +49,9 @@ class Testcase(Testing):
         logger.info(">>>step4: owner option is null value")
         self.vw_option_update_value(option_tested, '', config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["owner not in|owner.* not set|virt-who can't be started|"
+        msg_list = ["owner not in|"
+                    "owner.* not set|"
+                    "virt-who can't be started|"
                     "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
@@ -71,7 +74,8 @@ class Testcase(Testing):
         self.vw_etc_d_mode_create(config_name_ok, config_file_ok)
         self.vw_option_disable(option_tested, config_file)
         data, tty_output, rhsm_output = self.vw_start(exp_error=True)
-        msg_list = ["owner not in|owner.* not set|"
+        msg_list = ["owner not in|"
+                    "owner.* not set|"
                     "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=1)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)

--- a/tests/tier2/tc_2016_validate_owner_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2016_validate_owner_option_in_etc_virtwho_d.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136587')
@@ -32,7 +33,7 @@ class Testcase(Testing):
         self.vw_option_update_value(option_tested, "xxxxxx", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         msg_list = ["owner.* is different|Communication with subscription manager failed"]
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
@@ -47,7 +48,8 @@ class Testcase(Testing):
         logger.info(">>>step4: owner option is null value")
         self.vw_option_update_value(option_tested, '', config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["owner not in|owner.* not set|virt-who can't be started|Communication with subscription manager failed"]
+        msg_list = ["owner not in|owner.* not set|virt-who can't be started|"
+                    "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step4', []).append(res1)
@@ -56,20 +58,21 @@ class Testcase(Testing):
         logger.info(">>>step5: owner option is disable")
         self.vw_option_disable(option_tested, config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["owner not in|owner.* not set|virt-who can't be started|Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=0, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)
 
         logger.info(">>>step6: owner option is disable but another config is ok")
-        logger.warning("libvirt-local mode will be used to instead when type option is disabled")
+        logger.warning(
+            "libvirt-local mode will be used to instead when type option is disabled")
         config_name_ok = "virtwho-config-ok"
         config_file_ok = "/etc/virt-who.d/{0}.conf".format(config_name_ok)
         self.vw_etc_d_mode_create(config_name_ok, config_file_ok)
         self.vw_option_disable(option_tested, config_file)
         data, tty_output, rhsm_output = self.vw_start(exp_error=True)
-        msg_list = ["owner not in|owner.* not set|Communication with subscription manager failed"]
+        msg_list = ["owner not in|owner.* not set|"
+                    "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=1)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step6', []).append(res1)
@@ -79,7 +82,6 @@ class Testcase(Testing):
         self.vw_option_enable(option_tested, config_file)
         self.vw_option_update_value(option_tested, '', config_file)
         data, tty_output, rhsm_output = self.vw_start(exp_error=True)
-        msg_list = ["owner not in|owner.* not set|Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=1)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step7', []).append(res1)

--- a/tests/tier2/tc_2022_validate_rhsm_hostname_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2022_validate_rhsm_hostname_option_in_etc_virtwho_d.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136627')
@@ -30,7 +31,8 @@ class Testcase(Testing):
 
         # Case Steps
         try:
-            logger.info(">>>step1: run virt-who with rhsm_hostname, rhsm_port, rhsm_prefix good value")
+            logger.info(">>>step1: run virt-who with rhsm_hostname, rhsm_port, "
+                        "rhsm_prefix good value")
             self.vw_option_add("rhsm_hostname", register_server, config_file)
             self.vw_option_add("rhsm_port", "443", config_file)
             self.vw_option_add("rhsm_prefix", register_prefix, config_file)
@@ -44,15 +46,16 @@ class Testcase(Testing):
             self.vw_option_update_value("rhsm_hostname", "xxxxxx", config_file)
             data, tty_output, rhsm_output = self.vw_start()
             res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-            res2 = self.vw_msg_search(rhsm_output, "Name or service not known", exp_exist=True)
+            res2 = self.vw_msg_search(rhsm_output, "Name or service not known")
             results.setdefault('step2', []).append(res1)
             results.setdefault('step2', []).append(res2)
 
             logger.info(">>>step3: run virt-who with rhsm_hostname null value")
-            msg_list = ["Server error attempting a GET to /rhsm/status/|Communication with subscription manager failed"]
+            msg_list = ["Server error attempting a GET to /rhsm/status/|"
+                        "Communication with subscription manager failed"]
             self.vw_option_update_value("rhsm_hostname", " ", config_file)
             data, tty_output, rhsm_output = self.vw_start()
-            res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+            res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             res2 = self.msg_validation(rhsm_output, msg_list)
             results.setdefault('step3', []).append(res1)
             results.setdefault('step3', []).append(res2)
@@ -60,7 +63,7 @@ class Testcase(Testing):
             logger.info(">>>step4: run virt-who with rhsm_hostname disable")
             self.vw_option_disable("rhsm_hostname", config_file)
             data, tty_output, rhsm_output = self.vw_start()
-            res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+            res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             res2 = self.msg_validation(rhsm_output, msg_list)
             results.setdefault('step4', []).append(res1)
             results.setdefault('step4', []).append(res2)

--- a/tests/tier2/tc_2024_validate_rhsm_prefix_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2024_validate_rhsm_prefix_option_in_etc_virtwho_d.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-137169')
@@ -30,7 +31,8 @@ class Testcase(Testing):
 
         # Case Steps
         try:
-            logger.info(">>>step1: run virt-who with rhsm_hostname, rhsm_port, rhsm_prefix good value")
+            logger.info(">>>step1: run virt-who with rhsm_hostname, "
+                        "rhsm_port, rhsm_prefix good value")
             self.vw_option_add("rhsm_hostname", register_server, config_file)
             self.vw_option_add("rhsm_port", "443", config_file)
             self.vw_option_add("rhsm_prefix", register_prefix, config_file)
@@ -49,7 +51,7 @@ class Testcase(Testing):
             logger.info(">>>step3: run virt-who with rhsm_prefix null value")
             self.vw_option_update_value("rhsm_prefix", " ", config_file)
             data, tty_output, rhsm_output = self.vw_start()
-            res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+            res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, 'HTTP error', exp_exist=True)
             results.setdefault('step3', []).append(res1)
             results.setdefault('step3', []).append(res2)
@@ -57,10 +59,10 @@ class Testcase(Testing):
             logger.info(">>>step4: run virt-who with rhsm_prefix disable")
             self.vw_option_disable("rhsm_prefix", config_file)
             data, tty_output, rhsm_output = self.vw_start()
-            res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+            res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, 'HTTP error', exp_exist=True)
-            results.setdefault('step4', []).append(res1)
-            results.setdefault('step4', []).append(res2)
+            results.setdefault('step3', []).append(res1)
+            results.setdefault('step3', []).append(res2)
 
         except:
             results.setdefault('step', []).append(False)
@@ -73,6 +75,7 @@ class Testcase(Testing):
         notes = list()
         server_type = self.get_config('register_type')
         if "stage" in server_type:
-            notes.append("Bug(Step3,4): virt-who send out mappings to Stage Candlepin without rhsm_prefix")
+            notes.append("Bug(Step3,4): virt-who send out mappings to Stage Candlepin "
+                         "without rhsm_prefix")
             notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1720072")
         self.vw_case_result(results, notes)

--- a/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136630')
@@ -28,7 +29,8 @@ class Testcase(Testing):
         self.system_unregister(self.ssh_host())
 
         # Case Steps
-        logger.info(">>>step1: run virt-who with rhsm_hostname, rhsm_port, rhsm_prefix good value")
+        logger.info(">>>step1: run virt-who with rhsm_hostname, rhsm_port, "
+                    "rhsm_prefix good value")
         self.vw_option_add("rhsm_hostname", register_server, config_file)
         self.vw_option_add("rhsm_port", "443", config_file)
         self.vw_option_add("rhsm_prefix", register_prefix, config_file)
@@ -39,10 +41,11 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: run virt-who with rhsm_username=xxxxxx")
+        msg = "Communication with subscription manager failed"
         self.vw_option_update_value("rhsm_username", "xxxxxx", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, "Communication with subscription manager failed", exp_exist=True)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
+        res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 
@@ -51,7 +54,7 @@ class Testcase(Testing):
         msg_list = ["codec can't decode|Communication with subscription manager failed"]
         self.vw_option_update_value("rhsm_username", "红帽©¥®ðπ∉", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step3', []).append(res1)
         results.setdefault('step3', []).append(res2)

--- a/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
@@ -41,17 +41,18 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: run virt-who with rhsm_username=xxxxxx")
-        msg = "Communication with subscription manager failed"
+        error_msg = "Communication with subscription manager failed"
         self.vw_option_update_value("rhsm_username", "xxxxxx", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
+        res2 = self.vw_msg_search(rhsm_output, error_msg, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 
         logger.info(">>>step3: run virt-who with rhsm_username=红帽©¥®ðπ∉")
         '''红帽©¥®ðπ∉ username is not supported by candlepin'''
-        msg_list = ["codec can't decode|Communication with subscription manager failed"]
+        msg_list = ["codec can't decode|"
+                    "Communication with subscription manager failed"]
         self.vw_option_update_value("rhsm_username", "红帽©¥®ðπ∉", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
@@ -60,10 +61,11 @@ class Testcase(Testing):
         results.setdefault('step3', []).append(res2)
 
         logger.info(">>>step4: run virt-who with rhsm_username null value")
+        error_msg = "system is not registered or you are not root"
         self.vw_option_update_value("rhsm_username", " ", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, "system is not registered or you are not root")
+        res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
 
@@ -71,7 +73,7 @@ class Testcase(Testing):
         self.vw_option_disable("rhsm_username", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, "system is not registered or you are not root")
+        res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)
 

--- a/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136631')
@@ -11,7 +12,6 @@ class Testcase(Testing):
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         self.vw_case_init()
-
 
         # Case Config
         results = dict()
@@ -29,7 +29,8 @@ class Testcase(Testing):
         self.system_unregister(self.ssh_host())
 
         # Case Steps
-        logger.info(">>>step1: run virt-who with rhsm_hostname, rhsm_port, rhsm_prefix good value")
+        logger.info(">>>step1: run virt-who with rhsm_hostname, "
+                    "rhsm_port, rhsm_prefix good value")
         self.vw_option_add("rhsm_hostname", register_server, config_file)
         self.vw_option_add("rhsm_port", "443", config_file)
         self.vw_option_add("rhsm_prefix", register_prefix, config_file)
@@ -40,10 +41,11 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: run virt-who with rhsm_password=xxxxxx")
+        error_msg = "Communication with subscription manager failed"
         self.vw_option_update_value("rhsm_password", "xxxxxx", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, "Communication with subscription manager failed", exp_exist=True)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
+        res2 = self.vw_msg_search(rhsm_output, error_msg, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 
@@ -52,16 +54,17 @@ class Testcase(Testing):
         msg_list = ["codec can't decode|Communication with subscription manager failed"]
         self.vw_option_update_value("rhsm_password", "红帽©¥®ðπ∉", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step3', []).append(res1)
         results.setdefault('step3', []).append(res2)
 
         logger.info(">>>step4: run virt-who with rhsm_password null value")
+        error_msg = "system is not registered or you are not root"
         self.vw_option_update_value("rhsm_password", " ", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, "system is not registered or you are not root")
+        res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
 
@@ -69,7 +72,7 @@ class Testcase(Testing):
         self.vw_option_disable("rhsm_password", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, "system is not registered or you are not root")
+        res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)
 

--- a/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
@@ -51,7 +51,8 @@ class Testcase(Testing):
 
         logger.info(">>>step3: run virt-who with rhsm_password=红帽©¥®ðπ∉")
         '''红帽©¥®ðπ∉ password is supported by candlepin'''
-        msg_list = ["codec can't decode|Communication with subscription manager failed"]
+        msg_list = ["codec can't decode|"
+                    "Communication with subscription manager failed"]
         self.vw_option_update_value("rhsm_password", "红帽©¥®ðπ∉", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)

--- a/tests/tier2/tc_2027_validate_rhsm_encrypted_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2027_validate_rhsm_encrypted_password_option_in_etc_virtwho_d.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136632')
@@ -40,10 +41,11 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: run virt-who with rhsm_encrypted_password=xxxxxx")
+        error_msg = "Communication with subscription manager failed"
         self.vw_option_update_value("rhsm_encrypted_password", "xxxxxx", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, "Communication with subscription manager failed", exp_exist=True)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
+        res2 = self.vw_msg_search(rhsm_output, error_msg, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 
@@ -57,10 +59,11 @@ class Testcase(Testing):
         # results.setdefault('step3', []).append(res2)
 
         logger.info(">>>step4: run virt-who with rhsm_encrypted_password null value")
+        error_msg = 'Option "rhsm_encrypted_password" cannot be decrypted'
         self.vw_option_update_value("rhsm_encrypted_password", " ", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, 'Option "rhsm_encrypted_password" cannot be decrypted', exp_exist=True)
+        res2 = self.vw_msg_search(rhsm_output, error_msg, exp_exist=True)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
 

--- a/tests/tier2/tc_2039_validate_defaults_owner_option_by_virtwho_conf.py
+++ b/tests/tier2/tc_2039_validate_defaults_owner_option_by_virtwho_conf.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136727')
@@ -27,7 +28,8 @@ class Testcase(Testing):
         register_owner = register_config['owner']
 
         # Case Steps
-        logger.info(">>>step1: disable owner option in /etc/virt-who.d/, set correct owner in /etc/virt-who.conf")
+        logger.info(">>>step1: disable owner option in /etc/virt-who.d/, "
+                    "set correct owner in /etc/virt-who.conf")
         self.vw_option_disable("owner", config_file)
         self.vw_option_enable("owner", virtwho_conf)
         self.vw_option_update_value("owner", register_owner, virtwho_conf)
@@ -37,44 +39,50 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res1)
         results.setdefault('step1', []).append(res2)
 
-        logger.info(">>>step2: disable owner option in /etc/virt-who.d/, set owner=xxxxxx in /etc/virt-who.conf")
+        logger.info(">>>step2: disable owner option in /etc/virt-who.d/, "
+                    "set owner=xxxxxx in /etc/virt-who.conf")
         self.vw_option_update_value("owner", "xxxxxx", virtwho_conf)
         data, tty_output, rhsm_output = self.vw_start()
         msg_list = ["owner.* is different|Communication with subscription manager failed"]
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 
         logger.info(">>>step3: skip this step because owner cannot be set to no-ascci")
-        # logger.info(">>>step3: disable owner option in /etc/virt-who.d/, set owner=红帽©¥®ðπ∉ in /etc/virt-who.conf")
+        # logger.info(">>>step3: disable owner option in /etc/virt-who.d/, "
+        #             "set owner=红帽©¥®ðπ∉ in /etc/virt-who.conf")
         # self.vw_option_update_value("owner", "红帽©¥®ðπ∉", virtwho_conf)
         # data, tty_output, rhsm_output = self.vw_start()
         # res1 = self.op_normal_value(data, exp_error="nz", exp_thread=1, exp_send=0)
         # results.setdefault('step3', []).append(res1)
 
-        logger.info(">>>step4: disable owner option in /etc/virt-who.d/, set owner= in /etc/virt-who.conf")
+        logger.info(">>>step4: disable owner option in /etc/virt-who.d/, "
+                    "set owner= in /etc/virt-who.conf")
         self.vw_option_update_value("owner", "", virtwho_conf)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["owner not in|owner.* not set|virt-who can't be started|Communication with subscription manager failed"]
+        msg_list = ["owner not in|owner.* not set|virt-who can't be started|"
+                    "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
 
-        logger.info(">>>step5: correct owner in /etc/virt-who.conf, but wrong owner in /etc/virt-who.d/ config file")
+        logger.info(">>>step5: correct owner in /etc/virt-who.conf, "
+                    "but wrong owner in /etc/virt-who.d/ config file")
         self.vw_option_update_value("owner", register_owner, virtwho_conf)
         self.vw_option_enable("owner", config_file)
         self.vw_option_update_value("owner", "xxxxxx", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         msg_list = ["owner.* is different|Communication with subscription manager failed"]
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)
 
         # Case Result
         self.vw_case_result(results)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tier2/tc_2039_validate_defaults_owner_option_by_virtwho_conf.py
+++ b/tests/tier2/tc_2039_validate_defaults_owner_option_by_virtwho_conf.py
@@ -43,7 +43,8 @@ class Testcase(Testing):
                     "set owner=xxxxxx in /etc/virt-who.conf")
         self.vw_option_update_value("owner", "xxxxxx", virtwho_conf)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["owner.* is different|Communication with subscription manager failed"]
+        msg_list = ["owner.* is different|"
+                    "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step2', []).append(res1)
@@ -61,7 +62,9 @@ class Testcase(Testing):
                     "set owner= in /etc/virt-who.conf")
         self.vw_option_update_value("owner", "", virtwho_conf)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["owner not in|owner.* not set|virt-who can't be started|"
+        msg_list = ["owner not in|"
+                    "owner.* not set|"
+                    "virt-who can't be started|"
                     "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
@@ -74,7 +77,8 @@ class Testcase(Testing):
         self.vw_option_enable("owner", config_file)
         self.vw_option_update_value("owner", "xxxxxx", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["owner.* is different|Communication with subscription manager failed"]
+        msg_list = ["owner.* is different|"
+                    "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step5', []).append(res1)

--- a/tests/tier2/tc_2047_check_rhsm_log_after_delete_host_hypervisor_from_server_webui.py
+++ b/tests/tier2/tc_2047_check_rhsm_log_after_delete_host_hypervisor_from_server_webui.py
@@ -35,7 +35,8 @@ class Testcase(Testing):
             res1 = self.vw_web_host_delete(vw_host_name, vw_host_uuid)
             data, tty_output, rhsm_output = self.vw_start(exp_send=0, exp_error=True)
             res2 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
-            error_msg = ["consumer no longer exists|.*has been deleted"]
+            error_msg = ["consumer no longer exists|"
+                         ".*has been deleted"]
             res3 = self.msg_validation(rhsm_output, error_msg, exp_exist=True)
             results.setdefault('step2', []).append(res1)
             results.setdefault('step2', []).append(res2)

--- a/tests/tier2/tc_2047_check_rhsm_log_after_delete_host_hypervisor_from_server_webui.py
+++ b/tests/tier2/tc_2047_check_rhsm_log_after_delete_host_hypervisor_from_server_webui.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-137103')
@@ -33,7 +34,7 @@ class Testcase(Testing):
             vw_host_uuid='xxx'
             res1 = self.vw_web_host_delete(vw_host_name, vw_host_uuid)
             data, tty_output, rhsm_output = self.vw_start(exp_send=0, exp_error=True)
-            res2 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+            res2 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             error_msg = ["consumer no longer exists|.*has been deleted"]
             res3 = self.msg_validation(rhsm_output, error_msg, exp_exist=True)
             results.setdefault('step2', []).append(res1)

--- a/tests/tier2/tc_2059_check_redundant_options_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2059_check_redundant_options_in_etc_virtwho_d.py
@@ -1,0 +1,48 @@
+# coding:utf-8
+from virt_who import *
+from virt_who.base import Base
+from virt_who.register import Register
+from virt_who.testing import Testing
+
+
+class Testcase(Testing):
+    def test_run(self):
+        self.vw_case_info(os.path.basename(__file__), case_id='RHEL-137103')
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type in ('libvirt-local', 'vdsm'):
+            self.vw_case_skip(hypervisor_type)
+        self.vw_case_init()
+
+        # Case Config
+        results = dict()
+        self.vw_option_enable('[global]', '/etc/virt-who.conf')
+        self.vw_option_enable('debug', '/etc/virt-who.conf')
+        self.vw_option_update_value('debug', 'True', '/etc/virt-who.conf')
+        config_name = "virtwho-config"
+        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+        self.vw_etc_d_mode_create(config_name, config_file)
+        option = "hypervisor_id"
+        war_msg = "option '{0}' in section .* already exists".format(option)
+
+        # Case Steps
+        logger.info(">>>step1: run virt-who with hypervisor_id=uuid "
+                    "and hypervisor_id=hostname together")
+        self.vw_option_add(option, 'uuid', config_file)
+        self.vw_option_add(option, 'hostname', config_file)
+        data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+        res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+        res2 = self.vw_msg_search(rhsm_output, war_msg)
+        results.setdefault('step1', []).append(res1)
+        results.setdefault('step1', []).append(res2)
+
+        logger.info(">>>step2: add another hypervisor_id=xxx")
+        logger.info("if redundant options are configured, virt-who uses the last one")
+        self.vw_option_add(option, 'xxx', config_file)
+        data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+        res1 = self.op_normal_value(data, exp_error='nz', exp_thread=0, exp_send=0)
+        res2 = self.vw_msg_search(rhsm_output, war_msg)
+        results.setdefault('step2', []).append(res1)
+        results.setdefault('step2', []).append(res2)
+
+        # Case Result
+        self.vw_case_result(results)


### PR DESCRIPTION
1. new add tc_2059 to check warning message will be printed if configure two or more same options in /etc/virt-who.d/x.conf, and it will use the last one configuration.
2. update tc_2014 because new behaviors for section header. (bz1738846)
null value []: failed to start virt-who
space [ ]: failed to start virt-who
3. update testcase due to new function heartbeat, which prints related traceback message to rhsm.log. (bz1739118)