### PR TITLE
need to access the libvirt server without password

### DIFF
--- a/utils/installer.py
+++ b/utils/installer.py
@@ -87,6 +87,7 @@ def install_satellite(args):
     provision.runcmd(
         'hammer settings set --name=unregister_delete_host --value=true',
         ssh_sat)
+    provision.ssh_no_passwd_access(ssh_sat)
     update_section('satellite', 'hostname', host)
     update_section('satellite', 'ssh_username', username)
     update_section('satellite', 'ssh_password', password)


### PR DESCRIPTION
It's necessary to  update the satellite server and make sure it can access the libvirt remote server without password.