### PR TITLE
change range(60) to range(10) for vcenter_guest_ip()

### DIFF
--- a/virt_who/base.py
+++ b/virt_who/base.py
@@ -273,7 +273,7 @@ class Base(unittest.TestCase):
     def ssh_is_connected(self, ssh):
         host = ssh['host']
         cmd ="rpm -qa filesystem"
-        for i in range(360):
+        for i in range(60):
             ret, output = self.runcmd(cmd, ssh)
             if ret == 0 and "filesystem" in output:
                 logger.info("Succeeded to connect host {0} by ssh".format(host))

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2000,7 +2000,7 @@ class Provision(Register):
 
     def vcenter_guest_ip(self, cert, ssh_vcenter, guest_name):
         cmd = "%s Get-VM %s | %%{(Get-View $_.Id).Guest}" % (cert, guest_name)
-        for i in range(60):
+        for i in range(10):
             ret, output = self.runcmd(cmd, ssh_vcenter)
             if ret == 0 and "IpAddress" in output:
                 datalines = output.splitlines()


### PR DESCRIPTION
Waiting time (60*30s ) is too long when no guest ip found for vCenter, so change range(60) to range(10).