### PR TITLE
Path rhel81 snap3

### DIFF
--- a/tests/tier1/tc_1108_check_hypervisor_facts.py
+++ b/tests/tier1/tc_1108_check_hypervisor_facts.py
@@ -77,7 +77,12 @@ class Testcase(Testing):
             results.setdefault('step3', []).append(False)
 
         logger.info(">>>step4: check dmi.system.uuid value")
-        if facts_dic['dmi'] == host_uuid:
+        if hypervisor_type == "rhevm":
+            host_hwuuid = self.get_hypervisor_hwuuid()
+            dmi = host_hwuuid
+        else:
+            dmi = host_uuid
+        if facts_dic['dmi'] == dmi:
             logger.info("succeeded to check dmi.system.uuid={0}".format(host_uuid))
             results.setdefault('step4', []).append(True)
         else:
@@ -96,8 +101,4 @@ class Testcase(Testing):
                 results.setdefault('step5', []).append(False)
 
         # Case Result
-        notes = list()
-        if hypervisor_type == 'xen':
-            notes.append("(step4) [RHEVM] dmi.system.uuid is not uuid")
-            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1744057")
-        self.vw_case_result(results, notes)
+        self.vw_case_result(results)

--- a/tests/tier2/tc_2035_validate_global_report_id_by_virtwho_conf.py
+++ b/tests/tier2/tc_2035_validate_global_report_id_by_virtwho_conf.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136716')
@@ -19,26 +20,40 @@ class Testcase(Testing):
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
         reporter_id_null = ''
-        reporter_id_non_ascii = '红帽©¥®ðπ∉'
-        steps = {'step1':reporter_id_null, 'step2':reporter_id_non_ascii}
+        reporter_id_non_ascii = "红帽©¥®ðπ∉"
+        steps = {'step2': reporter_id_null,
+                 'step3': reporter_id_non_ascii}
 
         # Case Steps
-        for step, value in sorted(steps.items(),key=lambda item:item[0]):
-            logger.info(">>>{0}: run virt-who to check reporter_id({1})".format(step, value))
+        logger.info(">>>step1: get default reporter_id")
+        data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+        default_reporter_id = data['reporter_id']
+        logger.info("default reporter_id is {0}".format(default_reporter_id))
+        results.setdefault("step1", []).append(res)
+
+        for step, value in sorted(steps.items(), key=lambda item: item[0]):
+            logger.info(">>>{0}: run virt-who to check reporter_id({1})".format(
+                step, value))
             self.vw_option_enable("reporter_id", virtwho_conf)
             self.vw_option_update_value("reporter_id", value, virtwho_conf)
             data, tty_output, rhsm_output = self.vw_start(exp_send=1)
             res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault(step, []).append(res)
-            if value in data['reporter_id']:
-                logger.info("Succeeded to check, the reporter_id({0}) is expected".format(data['reporter_id']))
+            data['reporter_id'] = data['reporter_id'].encode("utf8")
+            if value == reporter_id_null:
+                value = default_reporter_id
+            if value == data['reporter_id']:
+                logger.info("Succeeded to check, reporter_id({0}) is expected".format(
+                    data['reporter_id']))
                 results.setdefault(step, []).append(True)
             else:
-                logger.info("Failed to check, the reporter_id({0}) is not expected".format(data['reporter_id']))
+                logger.error("Failed to check, reporter_id({0}) is not expected".format(
+                    data['reporter_id']))
                 results.setdefault(step, []).append(False)
 
         # Case Result
         notes = list()
-        notes.append("Bug(step1): virt-who still uses null value for reporter_id to report")
-        notes.append("BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1523067")
+        notes.append("Bug(step2): virt-who still uses null value for reporter_id")
+        notes.append("BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1750206")
         self.vw_case_result(results, notes)

--- a/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
+++ b/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
@@ -23,11 +23,6 @@ class Testcase(Testing):
         config_name = "virtwho-config"
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
-        msg_list = [
-            "Name or service not known|"
-            "Connection timed out|"
-            "Failed to connect|"
-            "Error in .* backend"]
 
         # Case Steps
         logger.info(">>>step1: run virt-who with all good configurations")
@@ -35,12 +30,13 @@ class Testcase(Testing):
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step1', []).append(res1)
 
-        logger.info(">>>step2: add useless line with tab spaces after server=")
-        cmd = "sed -i '/^server=/a \\\txxx=xxx' {0}".format(config_file)
+        logger.info(">>>step2: add useless line with tab spaces after type=")
+        cmd = "sed -i '/^type=/a \\\txxx=xxx' {0}".format(config_file)
         ret, output = self.runcmd(cmd, self.ssh_host(), desc="add new line with tab")
         data, tty_output, rhsm_output = self.vw_start(exp_send=0)
-        res1 = self.op_normal_value(data, exp_error="nz", exp_thread=1, exp_send=0)
-        res2 = self.msg_validation(rhsm_output, msg_list)
+        msg = "virt-who can't be started"
+        res1 = self.op_normal_value(data, exp_error=1, exp_thread=0, exp_send=0)
+        res2 = self.vw_msg_search(rhsm_output, msg)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -878,6 +878,7 @@ class Testing(Provision):
         ret, output = self.runcmd(cmd, self.ssh_host(), desc="virt-who placing number check")
         keys = re.findall(r'Report for config "(.*?)"', output)
         if output is not None and output != "" and len(keys) > 0:
+            keys[0] = keys[0].encode("utf8")
             key = "Report for config \"%s\" gathered, placing in datastore" % keys[0]
             cmd = "grep '%s' /var/log/rhsm/rhsm.log | wc -l" % key
             ret, output = self.runcmd(cmd, self.ssh_host(), desc="virt-who placing number check")


### PR DESCRIPTION
1. tc_1108_check_hypervisor_facts.py
   -  for rhevm, "dmi.system.uuid" is hwuuid.
2. tc_2035_validate_global_report_id_by_virtwho_conf.py 
    - report new bug bz750206", when reporter_id is null, virt-who cannot use default value.
    - fix unicode/str encode issue
3. tc_2060_check_commented_out_line_with_tab_space.py
    - add new line below type= option, because for kubevirt no server= option
4. virt_who/testing.py
    - fix unicode/str encode issue, which made tc_2014 failed.