### PR TITLE
Patch rhel78 alpha

### DIFF
--- a/tests/tier1/tc_1106_check_global_print_option_in_etc_virtwho_conf.py
+++ b/tests/tier1/tc_1106_check_global_print_option_in_etc_virtwho_conf.py
@@ -17,7 +17,6 @@ class Testcase(Testing):
         config_name = "virtwho-config"
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
-        host_uuid = self.get_hypervisor_hostuuid()
         guest_uuid = self.get_hypervisor_guestuuid()
 
         # case steps
@@ -56,15 +55,15 @@ class Testcase(Testing):
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)
 
-        # logger.info('>>>step5: Configure "print_=true" then start virt-who service')
-        # self.vw_stop()
-        # data, tty_output, rhsm_output = self.vw_start()
-        # res1 = self.op_normal_value(data, exp_error=0, exp_thread=0, exp_send=0)
-        # res2 = self.vw_msg_search(rhsm_output, guest_uuid, exp_exist=True)
-        # results.setdefault('step5', []).append(res1)
-        # results.setdefault('step5', []).append(res2)
+        logger.info('>>>step5: Configure "print_=true" then start virt-who service')
+        self.vw_stop()
+        data, tty_output, rhsm_output = self.vw_start("virt-who")
+        res1 = self.op_normal_value(data, exp_error=0, exp_thread=0, exp_send=0)
+        res2 = self.vw_msg_search(rhsm_output, guest_uuid, exp_exist=False)
+        results.setdefault('step5', []).append(res1)
+        results.setdefault('step5', []).append(res2)
 
-        logger.info('>>>step5: Configure "print_=xxx" then start virt-who service')
+        logger.info('>>>step6: Configure "print_=xxx" then start virt-who service')
         msg = "print_ must be a valid boolean"
         self.vw_option_update_value("print_", 'xxx', virtwho_conf)
         data, tty_output, rhsm_output = self.vw_start()

--- a/tests/tier2/tc_2059_check_redundant_options_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2059_check_redundant_options_in_etc_virtwho_d.py
@@ -21,7 +21,9 @@ class Testcase(Testing):
         config_name = "virtwho-config"
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
+        compose_id = self.get_config('rhel_compose')
         option = "hypervisor_id"
+        # bz1751603, only print war_msg for rhel8 using python3
         war_msg = "option '{0}' in section .* already exists".format(option)
 
         # Case Steps
@@ -31,18 +33,20 @@ class Testcase(Testing):
         self.vw_option_add(option, 'hostname', config_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-        res2 = self.vw_msg_search(rhsm_output, war_msg)
         results.setdefault('step1', []).append(res1)
-        results.setdefault('step1', []).append(res2)
+        if "RHEL-8" in compose_id:
+            res2 = self.vw_msg_search(rhsm_output, war_msg)
+            results.setdefault('step1', []).append(res2)
 
         logger.info(">>>step2: add another hypervisor_id=xxx")
-        logger.info("if redundant options are configured, virt-who uses the last one")
+        # if redundant options are configured, virt-who uses the last one
         self.vw_option_add(option, 'xxx', config_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
         res1 = self.op_normal_value(data, exp_error='nz', exp_thread=0, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, war_msg)
         results.setdefault('step2', []).append(res1)
-        results.setdefault('step2', []).append(res2)
+        if "RHEL-8" in compose_id:
+            res2 = self.vw_msg_search(rhsm_output, war_msg)
+            results.setdefault('step2', []).append(res2)
 
         # Case Result
         self.vw_case_result(results)

--- a/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
+++ b/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
@@ -23,6 +23,7 @@ class Testcase(Testing):
         config_name = "virtwho-config"
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
+        compose_id = self.get_config('rhel_compose')
 
         # Case Steps
         logger.info(">>>step1: run virt-who with all good configurations")
@@ -43,8 +44,14 @@ class Testcase(Testing):
         logger.info(">>>step3: comment out the useless line")
         cmd = 'sed -i "s/xxx/#xxx/" {0}'.format(config_file)
         ret, output = self.runcmd(cmd, self.ssh_host())
-        data, tty_output, rhsm_output = self.vw_start(exp_send=1)
-        res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+        if "RHEL-8" in compose_id:
+            data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+        if "RHEL-7" in compose_id:
+            war_msg = "A line continuation (line starts with space) that is commented " \
+                      "out was detected in file"
+            data, tty_output, rhsm_output = self.vw_start(exp_send=0)
+            res1 = self.op_normal_value(data, exp_error=1, exp_thread=0, exp_send=0)
         results.setdefault('step3', []).append(res1)
 
         # Case Result


### PR DESCRIPTION
(1). tc_1106_check_global_print_option_in_etc_virtwho_conf.py
       Bug 1714456 is fixed, when configure print_=True we can get all mapping info by running command "# virt-who".
(2). tc_2059_check_redundant_options_in_etc_virtwho_d.py 
      Bug 1751603 is closed as wontfix, so the behaviors are different for rhel7 and rhel8
(3). tc_2060_check_commented_out_line_with_tab_space.py
      Bug 1557296, behaviors are different for rhel7 and rhel8