### PR TITLE
add tc_2001/2002/2003/2004/2005/2007 back to rhel7 case library

### DIFF
--- a/tests/tier2/tc_2001_validate_owner_option_by_cli.py
+++ b/tests/tier2/tc_2001_validate_owner_option_by_cli.py
@@ -4,14 +4,16 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136568')
         hypervisor_type = self.get_config('hypervisor_type')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
         self.vw_case_init()
 
         # case config
@@ -19,6 +21,9 @@ class Testcase(Testing):
         if hypervisor_type == 'libvirt-remote':
             hypervisor_type = 'libvirt'
         base_cli = self.vw_cli_base() + '-d'
+        msg_list = ["owner not in|"
+                      "owner.* not set|"
+                      "virt-who can't be started"]
 
         # Case Steps
         logger.info(">>>step1: owner option is good value")
@@ -27,36 +32,46 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
  
         logger.info(">>>step2: owner option is wrong value")
-        cli = self.vw_cli_base_update(base_cli, '--{0}-owner=.*'.format(hypervisor_type), '--{0}-owner=xxxxx'.format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      '--{0}-owner=.*'.format(hypervisor_type),
+                                      '--{0}-owner=xxxxx'.format(hypervisor_type))
+        msg_list_2 = ["owner.* is different|"
+                      "Communication with subscription manager failed"]
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["owner.* is different|Communication with subscription manager failed"]
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
-        res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
+        res2 = self.msg_validation(rhsm_output, msg_list_2, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 
-        logger.info(">>>step3: owner option is 红帽€467aa value")
-        cli = self.vw_cli_base_update(base_cli, '--{0}-owner=.*'.format(hypervisor_type), '--{0}-owner=红帽€467aa'.format(hypervisor_type))
-        data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["codec can't decode|codec can't encode|Communication with subscription manager failed|owner.* is different"]
-        res1 = self.op_normal_value(data, exp_error="1|3", exp_thread=1, exp_send=0)
-        res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
-        results.setdefault('step3', []).append(res1)
-        results.setdefault('step3', []).append(res2)
+        logger.info(">>>step3: skip this step because owner cannot be set to no-ascci")
+        # cli = self.vw_cli_base_update(base_cli,
+        #                               '--{0}-owner=.*'.format(hypervisor_type),
+        #                               '--{0}-owner=红帽€467aa'.format(hypervisor_type))
+        # data, tty_output, rhsm_output = self.vw_start(cli)
+        # msg_list = ["codec can't decode|"
+        #             "codec can't encode|"
+        #             "Communication with subscription manager failed|"
+        #             "owner.* is different"]
+        # res1 = self.op_normal_value(data, exp_error="1|3", exp_thread=1, exp_send=0)
+        # res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        # results.setdefault('step3', []).append(res1)
+        # results.setdefault('step3', []).append(res2)
 
         logger.info(">>>step4: owner option is null value")
-        cli = self.vw_cli_base_update(base_cli, '--{0}-owner=.*'.format(hypervisor_type), '--{0}-owner= '.format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      '--{0}-owner=.*'.format(hypervisor_type),
+                                      '--{0}-owner= '.format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["owner not in|owner.* not set|virt-who can't be started"]
         res1 = self.op_normal_value(data, exp_error="0|1|2", exp_thread=0, exp_send=0)
         res2 = self.msg_validation(tty_output, msg_list, exp_exist=True)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
 
         logger.info(">>>step5: owner option is disable")
-        cli = self.vw_cli_base_update(base_cli, '--{0}-owner=.*'.format(hypervisor_type), ' ')
+        cli = self.vw_cli_base_update(base_cli,
+                                      '--{0}-owner=.*'.format(hypervisor_type),
+                                      ' ')
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["owner not in|owner.* not set|virt-who can't be started"]
         res1 = self.op_normal_value(data, exp_error="0|1|2", exp_thread=0, exp_send=0)
         res2 = self.msg_validation(tty_output, msg_list, exp_exist=True)
         results.setdefault('step5', []).append(res1)

--- a/tests/tier2/tc_2002_validate_env_option_by_cli.py
+++ b/tests/tier2/tc_2002_validate_env_option_by_cli.py
@@ -4,13 +4,17 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136571')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
+        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.24.6':
             self.vw_case_skip("virt-who version")
         self.vw_case_init()
 
@@ -27,34 +31,46 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: env option is wrong value")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-env=.*".format(hypervisor_type), "--{0}-env=xxxxx".format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli, "--{0}-env=.*".format(hypervisor_type),
+                                      "--{0}-env=xxxxx".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["env.*differs|env.* is different|Communication with subscription manager failed"]
+        msg_list = ["env.*differs|"
+                    "env.* is different|"
+                    "Communication with subscription manager failed"]
         res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 
         logger.info(">>>step3: env option is 红帽€467aa value")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-env=.*".format(hypervisor_type), "--{0}-env=红帽€467aa".format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-env=.*".format(hypervisor_type),
+                                      "--{0}-env=红帽€467aa".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["codec can't decode|Communication with subscription manager failed|env.*differs"]
+        msg_list = ["codec can't decode|"
+                    "Communication with subscription manager failed|"
+                    "env.*differs"]
         res1 = self.op_normal_value(data, exp_error="1|3", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step3', []).append(res1)
         results.setdefault('step3', []).append(res2)
 
         logger.info(">>>step4: env option is null value")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-env=.*".format(hypervisor_type), "--{0}-env= ".format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-env=.*".format(hypervisor_type),
+                                      "--{0}-env= ".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["env not in|env.* not set|virt-who can't be started"]
+        msg_list = ["env not in|env.* not set|"
+                    "virt-who can't be started"]
         res1 = self.op_normal_value(data, exp_error="0|1|2", exp_thread=0, exp_send=0)
         res2 = self.msg_validation(tty_output, msg_list, exp_exist=True)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
 
         logger.info(">>>step5: env option is disable")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-env=.*".format(hypervisor_type), " ")
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-env=.*".format(hypervisor_type),
+                                      " ")
         data, tty_output, rhsm_output = self.vw_start(cli)
         msg_list = ["env not in|env.* not set|virt-who can't be started"]
         res1 = self.op_normal_value(data, exp_error="0|1|2", exp_thread=0, exp_send=0)
@@ -66,6 +82,7 @@ class Testcase(Testing):
         notes = list()
         register_type = self.get_config('register_type')
         if "stage" in register_type:
-            notes.append("Bug(Step2,Step3): Set env to wrong or special value, still can sent report normally for stage")
+            notes.append("Bug(Step2,Step3): Set env to wrong or special value,"
+                         " still can sent report normally for stage")
             notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1530426")
         self.vw_case_result(results, notes)

--- a/tests/tier2/tc_2003_validate_server_option_by_cli.py
+++ b/tests/tier2/tc_2003_validate_server_option_by_cli.py
@@ -4,14 +4,16 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136572')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
             self.vw_case_skip(hypervisor_type)
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
         self.vw_case_init()
 
         # Case Config
@@ -19,6 +21,10 @@ class Testcase(Testing):
         if hypervisor_type == 'libvirt-remote':
             hypervisor_type = 'libvirt'
         base_cli = self.vw_cli_base() + '-d'
+        msg_list = ["Name or service not known|"
+                    "Connection timed out|"
+                    "Failed to connect|"
+                    "Error in .* backend"]
 
         # Case Steps
         logger.info(">>>step1: server option is good value")
@@ -27,29 +33,39 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: server option is wrong value")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-server=.*".format(hypervisor_type), "--{0}-server=xxxxx".format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-server=.*".format(hypervisor_type),
+                                      "--{0}-server=xxxxx".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["Name or service not known|Connection timed out|Failed to connect|Error in .* backend"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 
         logger.info(">>>step3: server option is 红帽€467aa value")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-server=.*".format(hypervisor_type), "--{0}-server=红帽€467aa".format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-server=.*".format(hypervisor_type),
+                                      "--{0}-server=红帽€467aa".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["Name or service not known|Connection timed out|Failed to connect|Error in .* backend|Unable to connect|codec can't encode"]
+        msg_list_3 = ["Name or service not known|"
+                      "Connection timed out|"
+                      "Failed to connect|"
+                      "Error in .* backend|"
+                      "Unable to connect|"
+                      "codec can't encode"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
-        res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        res2 = self.msg_validation(rhsm_output, msg_list_3, exp_exist=True)
         results.setdefault('step3', []).append(res1)
         results.setdefault('step3', []).append(res2)
 
         logger.info(">>>step4: server option is null value")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-server=.*".format(hypervisor_type), "--{0}-server= ".format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-server=.*".format(hypervisor_type),
+                                      "--{0}-server= ".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
         if "libvirt" in hypervisor_type:
-            logger.warning("libvirt-local mode will be used to instead when server option is null for libvirt-remote")
-            msg_list = ["Name or service not known|Connection timed out|Failed to connect|Error in .* backend"]
+            logger.warning("libvirt-local mode will be used to instead "
+                           "when server option is null for libvirt-remote")
             res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             res2 = self.msg_validation(tty_output, msg_list, exp_exist=True)
         else:
@@ -60,11 +76,13 @@ class Testcase(Testing):
         results.setdefault('step4', []).append(res2)
 
         logger.info(">>>step5: server option is disable")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-server=.*".format(hypervisor_type), " ")
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-server=.*".format(hypervisor_type),
+                                      " ")
         data, tty_output, rhsm_output = self.vw_start(cli)
         if "libvirt" in hypervisor_type:
-            logger.warning("libvirt-local mode will be used to instead when server option is disabled for libvirt-remote")
-            msg_list = ["Name or service not known|Connection timed out|Failed to connect|Error in .* backend"]
+            logger.warning("libvirt-local mode will be used to instead "
+                           "when server option is disabled for libvirt-remote")
             res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             res2 = self.msg_validation(tty_output, msg_list, exp_exist=True)
         else:

--- a/tests/tier2/tc_2004_validate_username_option_by_cli.py
+++ b/tests/tier2/tc_2004_validate_username_option_by_cli.py
@@ -4,14 +4,16 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136573')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
             self.vw_case_skip(hypervisor_type)
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
         self.vw_case_init()
 
         # Case Config
@@ -19,6 +21,13 @@ class Testcase(Testing):
         if hypervisor_type == 'libvirt-remote':
             hypervisor_type = 'libvirt'
         base_cli = self.vw_cli_base() + '-d'
+        msg_list = ["Unable to login|"
+                    "incorrect user.*|"
+                    "Authentication failure|"
+                    "Incorrect.*username|"
+                    "Unauthorized|"
+                    "Error.* backend|"
+                    "Permission denied"]
 
         # Case Steps
         logger.info(">>>step1: username option is good value")
@@ -27,28 +36,33 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: username option is wrong value")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-username=.*".format(hypervisor_type), "--{0}-username=xxxxx".format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-username=.*".format(hypervisor_type),
+                                      "--{0}-username=xxxxx".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["Unable to login|incorrect user.*|Authentication failure|Incorrect.*username|Unauthorized|Error.* backend|Permission denied"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
 
         logger.info(">>>step3: username option is 红帽€467aa value")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-username=.*".format(hypervisor_type), "--{0}-username=红帽€467aa".format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-username=.*".format(hypervisor_type),
+                                      "--{0}-username=红帽€467aa".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
-        msg_list = ["Unable to login|incorrect user.*|Authentication failure|Incorrect.*username|Unauthorized|Error.* backend|Permission denied"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step3', []).append(res1)
         results.setdefault('step3', []).append(res2)
 
         logger.info(">>>step4: username option is null value")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-username=.*".format(hypervisor_type), "--{0}-username= ".format(hypervisor_type))
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-username=.*".format(hypervisor_type),
+                                      "--{0}-username= ".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
         if "libvirt" in hypervisor_type:
-            logger.warning("libvirt-remote can use sshkey to connect, username is not necessary")
+            logger.warning("libvirt-remote can use sshkey to connect, "
+                           "username is not necessary")
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step4', []).append(res1)
         else:
@@ -59,10 +73,13 @@ class Testcase(Testing):
             results.setdefault('step4', []).append(res2)
 
         logger.info(">>>step5: username option is disable")
-        cli = self.vw_cli_base_update(base_cli, "--{0}-username=.*".format(hypervisor_type), " ")
+        cli = self.vw_cli_base_update(base_cli,
+                                      "--{0}-username=.*".format(hypervisor_type),
+                                      " ")
         data, tty_output, rhsm_output = self.vw_start(cli)
         if "libvirt" in hypervisor_type:
-            logger.warning("libvirt-remote can use sshkey to connect, username is not necessary")
+            logger.warning("libvirt-remote can use sshkey to connect, "
+                           "username is not necessary")
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step5', []).append(res1)
         else:
@@ -73,4 +90,8 @@ class Testcase(Testing):
             results.setdefault('step5', []).append(res2)
 
         # Case Result
-        self.vw_case_result(results)
+        notes = list()
+        if "rhevm" in hypervisor_type:
+            notes.append("Bug(Step3): username and password are not allowed")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751624")
+        self.vw_case_result(results, notes)

--- a/tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py
+++ b/tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py
@@ -4,14 +4,16 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136710')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
         self.vw_case_init()
 
         # Case Config
@@ -30,7 +32,9 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: run virt-who by cli with unconsistent parameters")
-        cli = re.sub("--{0}-owner=".format(hypervisor_type), "--{0}-owner=".format(wrong_mode), base_cli)
+        cli = re.sub("--{0}-owner=".format(hypervisor_type),
+                     "--{0}-owner=".format(wrong_mode),
+                     base_cli)
         data, tty_output, rhsm_output = self.vw_start(cli, exp_send=1)
         msg = "does not match virtualization backend"
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=0, exp_send=0)


### PR DESCRIPTION
After confirmation we got that all hypervisor backend options will still be available and supported to rhel7, so add those test cases back to rhel7 library.

And have debug all the cases locally, all succeed.