### PR TITLE
Add cli case 2

### DIFF
--- a/tests/tier1/tc_1003_check_virtwho_package_info.py
+++ b/tests/tier1/tc_1003_check_virtwho_package_info.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133656')
@@ -11,17 +12,21 @@ class Testcase(Testing):
         results = dict()
 
         logger.info(">>>step1: 'rpm -qi virt-who' contains valid 'Group' info")
-        results.setdefault('step1', []).append(pkg_info.get("Group") == "System Environment/Base")
+        results.setdefault('step1', []).append(
+            pkg_info.get("Group") == "System Environment/Base")
 
         logger.info(">>>step2: 'rpm -qi virt-who' contains valid 'License' info")
         results.setdefault('step2', []).append(pkg_info.get("License") == "GPLv2+")
 
         logger.info(">>>step3: 'rpm -qi virt-who' contains valid 'URL' info")
-        urls = ['https://github.com/virt-who/virt-who', 'https://github.com/candlepin/virt-who']
-        results.setdefault('step3', []).append(any(url in pkg_info.get("URL") for url in urls))
+        urls = ['https://github.com/virt-who/virt-who',
+                'https://github.com/candlepin/virt-who']
+        results.setdefault('step3', []).append(
+            any(url in pkg_info.get("URL") for url in urls))
 
         logger.info(">>>step4: 'rpm -qi virt-who' contains valid 'Packager' info")
-        results.setdefault('step4', []).append(pkg_info.get("Packager") == "Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>")
+        msg = "Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>"
+        results.setdefault('step4', []).append(pkg_info.get("Packager") == msg)
 
         logger.info(">>>step5: 'rpm -qi virt-who' contains valid 'Vendor' info")
         results.setdefault('step5', []).append(pkg_info.get("Vendor") == "Red Hat, Inc.")
@@ -32,5 +37,21 @@ class Testcase(Testing):
         logger.info(">>>step7: 'rpm -qi virt-who' contains valid 'Key ID' info")
         results.setdefault('step7', []).append("Key ID" in pkg_info.get("Signature"))
 
+        logger.info(">>>step8: 'virt-who --version' to check version")
+        vw_pkg = self.pkg_check(self.ssh_host(), 'virt-who')[9:15]
+        logger.info("virt-who version should be {0}".format(vw_pkg))
+        cmd = "virt-who --version"
+        ret, output = self.runcmd(cmd, self.ssh_host())
+        logger.info("'virt-who --version' output is {0}".format(output))
+        if ret == 0 and vw_pkg in output:
+            logger.info("succeed to check virt-who version {0}".format(vw_pkg))
+            results.setdefault('step8', []).append(True)
+        else:
+            logger.error("failed to check virt-who version by '#virt-who --version'")
+            results.setdefault('step8', []).append(False)
+
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        notes.append("Bug(Step8): Get wrong virt-who version by #virt-who --version")
+        notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1759869")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1009_check_virtwho_fetch_and_send_function_by_cli.py
+++ b/tests/tier1/tc_1009_check_virtwho_fetch_and_send_function_by_cli.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134108')
@@ -11,15 +12,19 @@ class Testcase(Testing):
 
         # case config
         results = dict()
-        config_name = "virtwho-config"
-        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-        self.vw_etc_d_mode_create(config_name, config_file)
         host_uuid = self.get_hypervisor_hostuuid()
         guest_uuid = self.get_hypervisor_guestuuid()
- 
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd = "virt-who -d"
+        else:
+            cmd = self.vw_cli_base() + '-d'
+
         # case steps
         logger.info(">>>step1: run virt-who by cli")
-        cmd = "virt-who -d"
         data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
         res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step1', []).append(res)

--- a/tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py
+++ b/tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133661')
@@ -11,21 +12,26 @@ class Testcase(Testing):
 
         # case config
         results = dict()
-        config_name = "virtwho-config"
-        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-        self.vw_etc_d_mode_create(config_name, config_file)
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd = "virt-who"
+            cmd_debug = "virt-who -d"
+        else:
+            cmd = self.vw_cli_base()
+            cmd_debug = self.vw_cli_base() + '-d'
 
         # case steps
         logger.info(">>>step1: Run virt-who by cli with -d option")
-        cmd = "virt-who -d"
-        data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
+        data, tty_output, rhsm_output = self.vw_start(cmd_debug, exp_send=1)
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         res2 = self.vw_msg_search(output=tty_output, msg="\[.*DEBUG\]", exp_exist=True)
         results.setdefault('step1', []).append(res1)
         results.setdefault('step1', []).append(res2)
 
         logger.info(">>>step2: Run virt-who by cli without -d option")
-        cmd = "virt-who"
         data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         res2 = self.vw_msg_search(output=tty_output, msg="\[.*DEBUG\]", exp_exist=False)
@@ -33,6 +39,4 @@ class Testcase(Testing):
         results.setdefault('step2', []).append(res2)
 
         # case result
-        notes = list()
-        notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1510712")
-        self.vw_case_result(results, notes)
+        self.vw_case_result(results)

--- a/tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py
+++ b/tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133649')
@@ -11,19 +12,25 @@ class Testcase(Testing):
 
         # case config
         results = dict()
-        config_name = "virtwho-config"
-        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-        self.vw_etc_d_mode_create(config_name, config_file)
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd = "virt-who"
+            cmd_oneshot = "virt-who -o"
+        else:
+            cmd = self.vw_cli_base()
+            cmd_oneshot = self.vw_cli_base() + "-o"
 
         # case step
         logger.info(">>>step1: Run virt-who by cli with -o option")
-        cmd = "virt-who -o"
-        data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1, oneshot=True)
+        data, tty_output, rhsm_output = self.vw_start(cmd_oneshot, exp_send=1,
+                                                      oneshot=True)
         res = self.op_normal_value(data, exp_error=0, exp_thread=0, exp_send=1)
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: Run virt-who by cli without -o option")
-        cmd = "virt-who"
         data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1, oneshot=False)
         res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step2', []).append(res)

--- a/tests/tier1/tc_1014_check_interval_function_by_cli.py
+++ b/tests/tier1/tc_1014_check_interval_function_by_cli.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133650')
@@ -11,33 +12,49 @@ class Testcase(Testing):
 
         # case config
         results = dict()
-        config_name = "virtwho-config"
-        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-        self.vw_etc_d_mode_create(config_name, config_file)
-        
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd = "virt-who -d"
+            cmd_i_10 = "virt-who -d -i 10"
+            cmd_i_60 = "virt-who -d -i 60"
+            cmd_i_120 = "virt-who -d -i 120"
+        else:
+            cmd = self.vw_cli_base() + "-d"
+            cmd_i_10 = self.vw_cli_base() + "-d -i 10"
+            cmd_i_60 = self.vw_cli_base() + "-d -i 60"
+            cmd_i_120 = self.vw_cli_base() + "-d -i 120"
+
         # case steps
         logger.info(">>>step1: run virt-who without -i option")
-        cmd = "virt-who -d"
         data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
-        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=3600)
+        res = self.op_normal_value(data, exp_error=0, exp_thread=1,
+                                   exp_send=1, exp_interval=3600)
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: run virt-who with -i 10 option")
-        cmd = "virt-who -d -i 10"
-        data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
-        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=3600)
-        results.setdefault('step2', []).append(res)
+        msg = "Interval value can't be lower than 60 seconds. " \
+              "Default value of 3600 seconds will be used"
+        data, tty_output, rhsm_output = self.vw_start(cmd_i_10, exp_send=1)
+        res1 = self.op_normal_value(data, exp_error=0, exp_thread=1,
+                                    exp_send=1, exp_interval=3600)
+        res2 = self.vw_msg_search(tty_output, msg, exp_exist=True)
+        results.setdefault('step2', []).append(res1)
+        results.setdefault('step2', []).append(res2)
 
         logger.info(">>>step3: run virt-who with -i 60 option")
-        cmd = "virt-who -d -i 60"
-        data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1, exp_loopnum=1)
-        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=60, exp_loopnum=1, exp_looptime=60)
+        data, tty_output, rhsm_output = self.vw_start(cmd_i_60, exp_send=1, exp_loopnum=1)
+        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1,
+                                   exp_interval=60, exp_loopnum=1, exp_looptime=60)
         results.setdefault('step3', []).append(res)
 
         logger.info(">>>step4: run virt-who with -i 120 option")
-        cmd = "virt-who -d -i 120"
-        data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1, exp_loopnum=1)
-        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=120, exp_loopnum=1, exp_looptime=120)
+        data, tty_output, rhsm_output = self.vw_start(cmd_i_120, exp_send=1,
+                                                      exp_loopnum=1)
+        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1,
+                                   exp_interval=120, exp_loopnum=1, exp_looptime=120)
         results.setdefault('step4', []).append(res)
 
         # case result

--- a/tests/tier1/tc_1016_check_print_function_by_cli.py
+++ b/tests/tier1/tc_1016_check_print_function_by_cli.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133653')
@@ -12,23 +13,33 @@ class Testcase(Testing):
         # case config
         results = dict()
         json_file = "/tmp/file.json"
-        config_name = "virtwho-config"
-        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-        self.vw_etc_d_mode_create(config_name, config_file)
         hypervisor_type = self.get_config('hypervisor_type')
         host_uuid = self.get_hypervisor_hostuuid()
         guest_uuid = self.get_hypervisor_guestuuid()
-        cmd1 = "virt-who -p > {0}".format(json_file)
-        cmd2 = "virt-who -p -d > {0}".format(json_file)
-        steps = {'step1':cmd1, 'step2':cmd2}
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd = "virt-who -p > {0}".format(json_file)
+            cmd_debug = "virt-who -d -p > {0}".format(json_file)
+        else:
+            cmd = self.vw_cli_base() + "-p > {0}".format(json_file)
+            cmd_debug = self.vw_cli_base() + "-d -p > {0}".format(json_file)
+        steps = {
+            'step1': cmd,
+            'step2': cmd_debug
+        }
 
         # case steps
-        for step, cmd in sorted(steps.items(),key=lambda item:item[0]):
+        for step, cmd in sorted(steps.items(), key=lambda item: item[0]):
             logger.info(">>>{0}: run virt-who cli to check print option".format(step))
-            data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=0, web_check=False)
+            data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=0,
+                                                          web_check=False)
             res = self.op_normal_value(data, exp_error=0, exp_thread=0, exp_send=0)
             results.setdefault(step, []).append(res)
-            ret, output = self.runcmd("cat {0}".format(json_file), self.ssh_host())
+            ret, output = self.runcmd("cat {0}".format(json_file),
+                                      self.ssh_host())
             res = self.vw_msg_search(output, guest_uuid, exp_exist=True)
             results.setdefault(step, []).append(res)
             if hypervisor_type not in ('libvirt-local', 'vdsm'):


### PR DESCRIPTION
As confirmation cli backend options will be still left and used in rhel7, so add related cases to rhel7 library.

Local debug results are as blow:
```
=============== test session starts ===============
tests/tier1/tc_1009_check_virtwho_fetch_and_send_function_by_cli.py .                            [ 16%]
tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py .                                     [ 33%]
tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py .                                   [ 66%]
tests/tier1/tc_1014_check_interval_function_by_cli.py .                                          [ 83%]
tests/tier1/tc_1016_check_print_function_by_cli.py .                                             [100%]

================ 5 passed in 1586.51 seconds ===============
```
```
tests/tier1/tc_1003_check_virtwho_package_info.py F                                              [100%]

Failed step: step8
Bug(Step8): Get wrong virt-who version by #virt-who --version
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1759869

```