### PR TITLE
add -m -l -d -r option testcase to rhel7

### DIFF
--- a/tests/tier1/tc_1018_check_log_per_config_function_by_cli.py
+++ b/tests/tier1/tc_1018_check_log_per_config_function_by_cli.py
@@ -4,11 +4,13 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133696')
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
         self.vw_case_init()
 
         # Case Config
@@ -16,10 +18,10 @@ class Testcase(Testing):
         guest_uuid = self.get_hypervisor_guestuuid()
         cmd1 = self.vw_cli_base() + "-d -m"
         cmd2 = self.vw_cli_base() + "-d --log-per-config"
-        steps = {'step1':cmd1, 'step2':cmd2}
+        steps = {'step1': cmd1, 'step2': cmd2}
 
         # Case Steps
-        for step, cmd in sorted(steps.items(),key=lambda item:item[0]):
+        for step, cmd in sorted(steps.items(), key=lambda item: item[0]):
             logger.info(">>>{0}: run virt-who cli to check log-per-config".format(step))
             data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
             res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)

--- a/tests/tier1/tc_1019_check_log_dir_function_by_cli.py
+++ b/tests/tier1/tc_1019_check_log_dir_function_by_cli.py
@@ -4,11 +4,13 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134121')
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
         self.vw_case_init()
 
         # case config
@@ -18,10 +20,10 @@ class Testcase(Testing):
         guest_uuid = self.get_hypervisor_guestuuid()
         cmd1 = self.vw_cli_base() + "-d -l {0}".format(log_dir)
         cmd2 = self.vw_cli_base() + "-d --log-dir {0}".format(log_dir)
-        steps = {'step1':cmd1, 'step2':cmd2}
+        steps = {'step1': cmd1, 'step2': cmd2}
 
         # case steps
-        for step, cmd in sorted(steps.items(),key=lambda item:item[0]):
+        for step, cmd in sorted(steps.items(), key=lambda item: item[0]):
             logger.info(">>>{0}: run virt-who cli to check log-dir".format(step))
             data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
             res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)

--- a/tests/tier1/tc_1020_check_log_file_function_by_cli.py
+++ b/tests/tier1/tc_1020_check_log_file_function_by_cli.py
@@ -7,8 +7,9 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134122')
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
+++ b/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
@@ -4,11 +4,13 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134123')
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
         self.vw_case_init()
 
         # case config
@@ -16,19 +18,21 @@ class Testcase(Testing):
         reporter_id = "virtwho_reporter_id_tc1021"
         cmd1 = self.vw_cli_base() + "-d -r {0}".format(reporter_id)
         cmd2 = self.vw_cli_base() + "-d --reporter-id {0}".format(reporter_id)
-        steps = {'step1':cmd1, 'step2':cmd2}
+        steps = {'step1': cmd1, 'step2': cmd2}
 
         # case steps
-        for step, cmd in sorted(steps.items(),key=lambda item:item[0]):
+        for step, cmd in sorted(steps.items(), key=lambda item: item[0]):
             logger.info(">>>{0}: run virt-who cli to check reporter_id".format(step))
             data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
             res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault(step, []).append(res)
             if data['reporter_id'] == reporter_id:
-                logger.info("Succeeded to find the expected reporter_id: {0}".format(reporter_id))
+                logger.info("Succeeded to find the expected reporter_id: {0}"
+                            .format(reporter_id))
                 results.setdefault(step, []).append(True)
             else:
-                logger.error("Failed to find the expected reporter_id: {0}".format(reporter_id))
+                logger.error("Failed to find the expected reporter_id: {0}"
+                             .format(reporter_id))
                 results.setdefault(step, []).append(False)
 
         # case result

--- a/tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py
+++ b/tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py
@@ -4,27 +4,30 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133748')
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-8" in compose_id:
+            self.vw_case_skip("RHEL-8")
         self.vw_case_init()
 
         # case config
         results = dict()
         cmd1 = self.vw_cli_base() + "--sam -d"
         cmd2 = self.vw_cli_base() + "--satellite6 -d"
-        steps = {'step1':cmd1, 'step2':cmd2}
+        steps = {'step1': cmd1, 'step2': cmd2}
 
         # case steps
-        for step, cmd in sorted(steps.items(),key=lambda item:item[0]):
-            logger.info(">>>{0}: run virt-who cli to check sam/satellite options".format(step))
+        for step, cmd in sorted(steps.items(), key=lambda item: item[0]):
+            logger.info(">>>{0}: run virt-who cli to check sam/satellite options"
+                        .format(step))
             data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
             s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault(step, []).append(s1)
 
         # case result
         notes = list()
-        notes.append("This case will be deprecated as bug https://bugzilla.redhat.com/show_bug.cgi?id=1368341")
+        notes.append("Bug 1760175 - Remove --sam/--satellite6 or repair them?")
         self.vw_case_result(results, notes)


### PR DESCRIPTION
-m -l -r -d and --satellite --sam arguments will be still used in rhel7, so add the testcases to rhel7 library.

Local debug results are as below:
```
=============== test session starts ========
tests/tier1/tc_1018_check_log_per_config_function_by_cli.py .                                    [ 20%]
tests/tier1/tc_1019_check_log_dir_function_by_cli.py .                                           [ 40%]
tests/tier1/tc_1020_check_log_file_function_by_cli.py .                                          [ 60%]
tests/tier1/tc_1021_check_reporter_id_function_by_cli.py .                                       [ 80%]
tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py .                                      [100%]

================= 5 passed in 1332.00 seconds ===============
```