### PR TITLE
Patch rhel78 beta1.3

### DIFF
--- a/tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py
+++ b/tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py
@@ -13,8 +13,7 @@ class Testcase(Testing):
         # case config
         results = dict()
         compose_id = self.get_config('rhel_compose')
-        hypervisor_type = self.get_config('hypervisor_type')
-        if "RHEL-8" in compose_id or 'kubevirt' in hypervisor_type:
+        if "RHEL-8" in compose_id:
             config_name = "virtwho-config"
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
             self.vw_etc_d_mode_create(config_name, config_file)
@@ -40,4 +39,9 @@ class Testcase(Testing):
         results.setdefault('step2', []).append(res2)
 
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py
+++ b/tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py
@@ -13,7 +13,8 @@ class Testcase(Testing):
         # case config
         results = dict()
         compose_id = self.get_config('rhel_compose')
-        if "RHEL-8" in compose_id:
+        hypervisor_type = self.get_config('hypervisor_type')
+        if "RHEL-8" in compose_id or 'kubevirt' in hypervisor_type:
             config_name = "virtwho-config"
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
             self.vw_etc_d_mode_create(config_name, config_file)

--- a/tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py
+++ b/tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py
@@ -13,7 +13,8 @@ class Testcase(Testing):
         # case config
         results = dict()
         compose_id = self.get_config('rhel_compose')
-        if "RHEL-8" in compose_id:
+        hypervisor_type = self.get_config('hypervisor_type')
+        if "RHEL-8" in compose_id or 'kubevirt' in hypervisor_type:
             config_name = "virtwho-config"
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
             self.vw_etc_d_mode_create(config_name, config_file)

--- a/tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py
+++ b/tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py
@@ -13,8 +13,7 @@ class Testcase(Testing):
         # case config
         results = dict()
         compose_id = self.get_config('rhel_compose')
-        hypervisor_type = self.get_config('hypervisor_type')
-        if "RHEL-8" in compose_id or 'kubevirt' in hypervisor_type:
+        if "RHEL-8" in compose_id:
             config_name = "virtwho-config"
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
             self.vw_etc_d_mode_create(config_name, config_file)
@@ -37,4 +36,9 @@ class Testcase(Testing):
         results.setdefault('step2', []).append(res)
 
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1014_check_interval_function_by_cli.py
+++ b/tests/tier1/tc_1014_check_interval_function_by_cli.py
@@ -13,7 +13,6 @@ class Testcase(Testing):
         # case config
         results = dict()
         compose_id = self.get_config('rhel_compose')
-        hypervisor_type = self.get_config('hypervisor_type')
         if "RHEL-8" in compose_id:
             config_name = "virtwho-config"
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)

--- a/tests/tier1/tc_1014_check_interval_function_by_cli.py
+++ b/tests/tier1/tc_1014_check_interval_function_by_cli.py
@@ -13,7 +13,8 @@ class Testcase(Testing):
         # case config
         results = dict()
         compose_id = self.get_config('rhel_compose')
-        if "RHEL-8" in compose_id:
+        hypervisor_type = self.get_config('hypervisor_type')
+        if "RHEL-8" in compose_id or 'kubevirt' in hypervisor_type:
             config_name = "virtwho-config"
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
             self.vw_etc_d_mode_create(config_name, config_file)

--- a/tests/tier1/tc_1014_check_interval_function_by_cli.py
+++ b/tests/tier1/tc_1014_check_interval_function_by_cli.py
@@ -14,7 +14,7 @@ class Testcase(Testing):
         results = dict()
         compose_id = self.get_config('rhel_compose')
         hypervisor_type = self.get_config('hypervisor_type')
-        if "RHEL-8" in compose_id or 'kubevirt' in hypervisor_type:
+        if "RHEL-8" in compose_id:
             config_name = "virtwho-config"
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
             self.vw_etc_d_mode_create(config_name, config_file)
@@ -59,4 +59,9 @@ class Testcase(Testing):
         results.setdefault('step4', []).append(res)
 
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2,3,4) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1016_check_print_function_by_cli.py
+++ b/tests/tier1/tc_1016_check_print_function_by_cli.py
@@ -13,7 +13,6 @@ class Testcase(Testing):
         # case config
         results = dict()
         json_file = "/tmp/file.json"
-        hypervisor_type = self.get_config('hypervisor_type')
         host_uuid = self.get_hypervisor_hostuuid()
         guest_uuid = self.get_hypervisor_guestuuid()
         compose_id = self.get_config('rhel_compose')

--- a/tests/tier1/tc_1016_check_print_function_by_cli.py
+++ b/tests/tier1/tc_1016_check_print_function_by_cli.py
@@ -17,7 +17,8 @@ class Testcase(Testing):
         host_uuid = self.get_hypervisor_hostuuid()
         guest_uuid = self.get_hypervisor_guestuuid()
         compose_id = self.get_config('rhel_compose')
-        if "RHEL-8" in compose_id:
+        hypervisor_type = self.get_config('hypervisor_type')
+        if "RHEL-8" in compose_id or 'kubevirt' in hypervisor_type:
             config_name = "virtwho-config"
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
             self.vw_etc_d_mode_create(config_name, config_file)

--- a/tests/tier1/tc_1016_check_print_function_by_cli.py
+++ b/tests/tier1/tc_1016_check_print_function_by_cli.py
@@ -18,7 +18,7 @@ class Testcase(Testing):
         guest_uuid = self.get_hypervisor_guestuuid()
         compose_id = self.get_config('rhel_compose')
         hypervisor_type = self.get_config('hypervisor_type')
-        if "RHEL-8" in compose_id or 'kubevirt' in hypervisor_type:
+        if "RHEL-8" in compose_id:
             config_name = "virtwho-config"
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
             self.vw_etc_d_mode_create(config_name, config_file)
@@ -48,4 +48,9 @@ class Testcase(Testing):
                 results.setdefault(step, []).append(res)
 
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1018_check_log_per_config_function_by_cli.py
+++ b/tests/tier1/tc_1018_check_log_per_config_function_by_cli.py
@@ -16,8 +16,16 @@ class Testcase(Testing):
         # Case Config
         results = dict()
         guest_uuid = self.get_hypervisor_guestuuid()
-        cmd1 = self.vw_cli_base() + "-d -m"
-        cmd2 = self.vw_cli_base() + "-d --log-per-config"
+        hypervisor_type = self.get_config('hypervisor_type')
+        if 'kubevirt' in hypervisor_type:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd1 = "virt-who -d -m"
+            cmd2 = "virt-who -d --log-per-config"
+        else:
+            cmd1 = self.vw_cli_base() + "-d -m"
+            cmd2 = self.vw_cli_base() + "-d --log-per-config"
         steps = {'step1': cmd1, 'step2': cmd2}
 
         # Case Steps

--- a/tests/tier1/tc_1018_check_log_per_config_function_by_cli.py
+++ b/tests/tier1/tc_1018_check_log_per_config_function_by_cli.py
@@ -16,16 +16,8 @@ class Testcase(Testing):
         # Case Config
         results = dict()
         guest_uuid = self.get_hypervisor_guestuuid()
-        hypervisor_type = self.get_config('hypervisor_type')
-        if 'kubevirt' in hypervisor_type:
-            config_name = "virtwho-config"
-            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-            self.vw_etc_d_mode_create(config_name, config_file)
-            cmd1 = "virt-who -d -m"
-            cmd2 = "virt-who -d --log-per-config"
-        else:
-            cmd1 = self.vw_cli_base() + "-d -m"
-            cmd2 = self.vw_cli_base() + "-d --log-per-config"
+        cmd1 = self.vw_cli_base() + "-d -m"
+        cmd2 = self.vw_cli_base() + "-d --log-per-config"
         steps = {'step1': cmd1, 'step2': cmd2}
 
         # Case Steps
@@ -78,4 +70,9 @@ class Testcase(Testing):
                         logger.error("Failed to validate virtwho.rhsm_log file")
                         results.setdefault(step, []).append(False)
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1019_check_log_dir_function_by_cli.py
+++ b/tests/tier1/tc_1019_check_log_dir_function_by_cli.py
@@ -18,7 +18,6 @@ class Testcase(Testing):
         log_dir = "/var/log/rhsm/virtwho/"
         log_file = "/var/log/rhsm/virtwho/rhsm.log"
         guest_uuid = self.get_hypervisor_guestuuid()
-        hypervisor_type = self.get_config('hypervisor_type')
         cmd1 = self.vw_cli_base() + "-d -l {0}".format(log_dir)
         cmd2 = self.vw_cli_base() + "-d --log-dir {0}".format(log_dir)
         steps = {'step1': cmd1, 'step2': cmd2}

--- a/tests/tier1/tc_1019_check_log_dir_function_by_cli.py
+++ b/tests/tier1/tc_1019_check_log_dir_function_by_cli.py
@@ -18,8 +18,16 @@ class Testcase(Testing):
         log_dir = "/var/log/rhsm/virtwho/"
         log_file = "/var/log/rhsm/virtwho/rhsm.log"
         guest_uuid = self.get_hypervisor_guestuuid()
-        cmd1 = self.vw_cli_base() + "-d -l {0}".format(log_dir)
-        cmd2 = self.vw_cli_base() + "-d --log-dir {0}".format(log_dir)
+        hypervisor_type = self.get_config('hypervisor_type')
+        if 'kubevirt' in hypervisor_type:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd1 = "virt-who -d -l {0}".format(log_dir)
+            cmd2 = "virt-who -d --log-dir {0}".format(log_dir)
+        else:
+            cmd1 = self.vw_cli_base() + "-d -l {0}".format(log_dir)
+            cmd2 = self.vw_cli_base() + "-d --log-dir {0}".format(log_dir)
         steps = {'step1': cmd1, 'step2': cmd2}
 
         # case steps

--- a/tests/tier1/tc_1019_check_log_dir_function_by_cli.py
+++ b/tests/tier1/tc_1019_check_log_dir_function_by_cli.py
@@ -19,15 +19,8 @@ class Testcase(Testing):
         log_file = "/var/log/rhsm/virtwho/rhsm.log"
         guest_uuid = self.get_hypervisor_guestuuid()
         hypervisor_type = self.get_config('hypervisor_type')
-        if 'kubevirt' in hypervisor_type:
-            config_name = "virtwho-config"
-            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-            self.vw_etc_d_mode_create(config_name, config_file)
-            cmd1 = "virt-who -d -l {0}".format(log_dir)
-            cmd2 = "virt-who -d --log-dir {0}".format(log_dir)
-        else:
-            cmd1 = self.vw_cli_base() + "-d -l {0}".format(log_dir)
-            cmd2 = self.vw_cli_base() + "-d --log-dir {0}".format(log_dir)
+        cmd1 = self.vw_cli_base() + "-d -l {0}".format(log_dir)
+        cmd2 = self.vw_cli_base() + "-d --log-dir {0}".format(log_dir)
         steps = {'step1': cmd1, 'step2': cmd2}
 
         # case steps
@@ -48,4 +41,9 @@ class Testcase(Testing):
                 results.setdefault(step, []).append(False)
 
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1020_check_log_file_function_by_cli.py
+++ b/tests/tier1/tc_1020_check_log_file_function_by_cli.py
@@ -17,8 +17,16 @@ class Testcase(Testing):
         log_dir = "/var/log/rhsm/virtwho"
         log_file = "/var/log/rhsm/virtwho/virtwho.log"
         guest_uuid = self.get_hypervisor_guestuuid()
-        cmd1 = self.vw_cli_base() + "-d -l {0} -f {1}".format(log_dir,log_file)
-        cmd2 = self.vw_cli_base() + "-d --log-dir {0} --log-file {1}".format(log_dir,log_file)
+        hypervisor_type = self.get_config('hypervisor_type')
+        if 'kubevirt' in hypervisor_type:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd1 = "virt-who -d -l {0} -f {1}".format(log_dir,log_file)
+            cmd2 = "virt-who -d --log-dir {0} --log-file {1}".format(log_dir,log_file)
+        else:
+            cmd1 = self.vw_cli_base() + "-d -l {0} -f {1}".format(log_dir,log_file)
+            cmd2 = self.vw_cli_base() + "-d --log-dir {0} --log-file {1}".format(log_dir,log_file)
         steps = {'step1':cmd1, 'step2':cmd2}
 
         # case steps

--- a/tests/tier1/tc_1020_check_log_file_function_by_cli.py
+++ b/tests/tier1/tc_1020_check_log_file_function_by_cli.py
@@ -17,16 +17,8 @@ class Testcase(Testing):
         log_dir = "/var/log/rhsm/virtwho"
         log_file = "/var/log/rhsm/virtwho/virtwho.log"
         guest_uuid = self.get_hypervisor_guestuuid()
-        hypervisor_type = self.get_config('hypervisor_type')
-        if 'kubevirt' in hypervisor_type:
-            config_name = "virtwho-config"
-            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-            self.vw_etc_d_mode_create(config_name, config_file)
-            cmd1 = "virt-who -d -l {0} -f {1}".format(log_dir,log_file)
-            cmd2 = "virt-who -d --log-dir {0} --log-file {1}".format(log_dir,log_file)
-        else:
-            cmd1 = self.vw_cli_base() + "-d -l {0} -f {1}".format(log_dir,log_file)
-            cmd2 = self.vw_cli_base() + "-d --log-dir {0} --log-file {1}".format(log_dir,log_file)
+        cmd1 = self.vw_cli_base() + "-d -l {0} -f {1}".format(log_dir,log_file)
+        cmd2 = self.vw_cli_base() + "-d --log-dir {0} --log-file {1}".format(log_dir,log_file)
         steps = {'step1':cmd1, 'step2':cmd2}
 
         # case steps
@@ -47,4 +39,9 @@ class Testcase(Testing):
                 results.setdefault(step, []).append(False)
 
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
+++ b/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
@@ -22,7 +22,7 @@ class Testcase(Testing):
             config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
             self.vw_etc_d_mode_create(config_name, config_file)
             cmd1 = "virt-who -d -r {0}".format(reporter_id)
-            cmd2 = "virt-who --reporter-id {0}".format(reporter_id)
+            cmd2 = "virt-who -d --reporter-id {0}".format(reporter_id)
         else:
             cmd1 = self.vw_cli_base() + "-d -r {0}".format(reporter_id)
             cmd2 = self.vw_cli_base() + "-d --reporter-id {0}".format(reporter_id)

--- a/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
+++ b/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
@@ -16,7 +16,6 @@ class Testcase(Testing):
         # case config
         results = dict()
         reporter_id = "virtwho_reporter_id_tc1021"
-        hypervisor_type = self.get_config('hypervisor_type')
         cmd1 = self.vw_cli_base() + "-d -r {0}".format(reporter_id)
         cmd2 = self.vw_cli_base() + "-d --reporter-id {0}".format(reporter_id)
         steps = {'step1': cmd1, 'step2': cmd2}

--- a/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
+++ b/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
@@ -16,8 +16,16 @@ class Testcase(Testing):
         # case config
         results = dict()
         reporter_id = "virtwho_reporter_id_tc1021"
-        cmd1 = self.vw_cli_base() + "-d -r {0}".format(reporter_id)
-        cmd2 = self.vw_cli_base() + "-d --reporter-id {0}".format(reporter_id)
+        hypervisor_type = self.get_config('hypervisor_type')
+        if 'kubevirt' in hypervisor_type:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd1 = "virt-who -d -r {0}".format(reporter_id)
+            cmd2 = "virt-who --reporter-id {0}".format(reporter_id)
+        else:
+            cmd1 = self.vw_cli_base() + "-d -r {0}".format(reporter_id)
+            cmd2 = self.vw_cli_base() + "-d --reporter-id {0}".format(reporter_id)
         steps = {'step1': cmd1, 'step2': cmd2}
 
         # case steps

--- a/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
+++ b/tests/tier1/tc_1021_check_reporter_id_function_by_cli.py
@@ -17,15 +17,8 @@ class Testcase(Testing):
         results = dict()
         reporter_id = "virtwho_reporter_id_tc1021"
         hypervisor_type = self.get_config('hypervisor_type')
-        if 'kubevirt' in hypervisor_type:
-            config_name = "virtwho-config"
-            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-            self.vw_etc_d_mode_create(config_name, config_file)
-            cmd1 = "virt-who -d -r {0}".format(reporter_id)
-            cmd2 = "virt-who -d --reporter-id {0}".format(reporter_id)
-        else:
-            cmd1 = self.vw_cli_base() + "-d -r {0}".format(reporter_id)
-            cmd2 = self.vw_cli_base() + "-d --reporter-id {0}".format(reporter_id)
+        cmd1 = self.vw_cli_base() + "-d -r {0}".format(reporter_id)
+        cmd2 = self.vw_cli_base() + "-d --reporter-id {0}".format(reporter_id)
         steps = {'step1': cmd1, 'step2': cmd2}
 
         # case steps
@@ -44,4 +37,9 @@ class Testcase(Testing):
                 results.setdefault(step, []).append(False)
 
         # case result
-        self.vw_case_result(results)
+        notes = list()
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py
+++ b/tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py
@@ -15,16 +15,8 @@ class Testcase(Testing):
 
         # case config
         results = dict()
-        hypervisor_type = self.get_config('hypervisor_type')
-        if 'kubevirt' in hypervisor_type:
-            config_name = "virtwho-config"
-            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
-            self.vw_etc_d_mode_create(config_name, config_file)
-            cmd1 = "virt-who --sam -d"
-            cmd2 = "virt-who --satellite6 -d"
-        else:
-            cmd1 = self.vw_cli_base() + "--sam -d"
-            cmd2 = self.vw_cli_base() + "--satellite6 -d"
+        cmd1 = self.vw_cli_base() + "--sam -d"
+        cmd2 = self.vw_cli_base() + "--satellite6 -d"
         steps = {'step1': cmd1, 'step2': cmd2}
 
         # case steps
@@ -38,4 +30,9 @@ class Testcase(Testing):
         # case result
         notes = list()
         notes.append("Bug 1760175 - Remove --sam/--satellite6 or repair them?")
+        notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1760175")
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
         self.vw_case_result(results, notes)

--- a/tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py
+++ b/tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py
@@ -15,8 +15,16 @@ class Testcase(Testing):
 
         # case config
         results = dict()
-        cmd1 = self.vw_cli_base() + "--sam -d"
-        cmd2 = self.vw_cli_base() + "--satellite6 -d"
+        hypervisor_type = self.get_config('hypervisor_type')
+        if 'kubevirt' in hypervisor_type:
+            config_name = "virtwho-config"
+            config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+            self.vw_etc_d_mode_create(config_name, config_file)
+            cmd1 = "virt-who --sam -d"
+            cmd2 = "virt-who --satellite6 -d"
+        else:
+            cmd1 = self.vw_cli_base() + "--sam -d"
+            cmd2 = self.vw_cli_base() + "--satellite6 -d"
         steps = {'step1': cmd1, 'step2': cmd2}
 
         # case steps

--- a/tests/tier2/tc_2001_validate_owner_option_by_cli.py
+++ b/tests/tier2/tc_2001_validate_owner_option_by_cli.py
@@ -9,7 +9,7 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136568')
         hypervisor_type = self.get_config('hypervisor_type')
-        if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
+        if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         compose_id = self.get_config('rhel_compose')
         if "RHEL-8" in compose_id:
@@ -78,4 +78,8 @@ class Testcase(Testing):
         results.setdefault('step5', []).append(res2)
 
         # Case Result
-        self.vw_case_result(results)
+        notes = list()
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1,2) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier2/tc_2001_validate_owner_option_by_cli.py
+++ b/tests/tier2/tc_2001_validate_owner_option_by_cli.py
@@ -9,7 +9,7 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136568')
         hypervisor_type = self.get_config('hypervisor_type')
-        if hypervisor_type in ('libvirt-local', 'vdsm'):
+        if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
             self.vw_case_skip(hypervisor_type)
         compose_id = self.get_config('rhel_compose')
         if "RHEL-8" in compose_id:

--- a/tests/tier2/tc_2002_validate_env_option_by_cli.py
+++ b/tests/tier2/tc_2002_validate_env_option_by_cli.py
@@ -10,7 +10,7 @@ class Testcase(Testing):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136571')
         hypervisor_type = self.get_config('hypervisor_type')
         compose_id = self.get_config('rhel_compose')
-        if hypervisor_type in ('libvirt-local', 'vdsm'):
+        if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
             self.vw_case_skip(hypervisor_type)
         if "RHEL-8" in compose_id:
             self.vw_case_skip("RHEL-8")

--- a/tests/tier2/tc_2002_validate_env_option_by_cli.py
+++ b/tests/tier2/tc_2002_validate_env_option_by_cli.py
@@ -10,7 +10,7 @@ class Testcase(Testing):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136571')
         hypervisor_type = self.get_config('hypervisor_type')
         compose_id = self.get_config('rhel_compose')
-        if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
+        if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         if "RHEL-8" in compose_id:
             self.vw_case_skip("RHEL-8")

--- a/tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py
+++ b/tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py
@@ -10,7 +10,7 @@ class Testcase(Testing):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136710')
         hypervisor_type = self.get_config('hypervisor_type')
         compose_id = self.get_config('rhel_compose')
-        if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
+        if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         if "RHEL-8" in compose_id:
             self.vw_case_skip("RHEL-8")
@@ -43,4 +43,8 @@ class Testcase(Testing):
         results.setdefault('step2', []).append(res2)
 
         # Case Result
-        self.vw_case_result(results)
+        notes = list()
+        if hypervisor_type == 'kubevirt':
+            notes.append("(step1) No kubeconfig option for cli")
+            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751441")
+        self.vw_case_result(results, notes)

--- a/tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py
+++ b/tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py
@@ -10,7 +10,7 @@ class Testcase(Testing):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136710')
         hypervisor_type = self.get_config('hypervisor_type')
         compose_id = self.get_config('rhel_compose')
-        if hypervisor_type in ('libvirt-local', 'vdsm'):
+        if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
             self.vw_case_skip(hypervisor_type)
         if "RHEL-8" in compose_id:
             self.vw_case_skip("RHEL-8")


### PR DESCRIPTION
(1). tc_2001,2002,2007: should skip the three cases for kubevirt because kubevirt doesn't support running by cli.
(2). other cases: also for kubevirt mode, when run virt-who by cli in this mode, one .conf file under /etc/virt-who.d/ is needed.
```
========== test session starts ================
collected 9 items                                                                                                                                

tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py .                                                                               [ 11%]
tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py .                                                           [ 22%]
tests/tier1/tc_1014_check_interval_function_by_cli.py .                                                                  [ 33%]
tests/tier1/tc_1016_check_print_function_by_cli.py .                                                                     [ 44%]
tests/tier1/tc_1018_check_log_per_config_function_by_cli.py .                                                            [ 55%]
tests/tier1/tc_1019_check_log_dir_function_by_cli.py .                                                                   [ 66%]
tests/tier1/tc_1020_check_log_file_function_by_cli.py .                                                                  [ 77%]
tests/tier1/tc_1021_check_reporter_id_function_by_cli.py .                                                               [ 88%]
tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py .                                                              [100%]

==================== 9 passed in 1490.41 seconds ================
```
