### PR TITLE
support to deploy nightly satellite

### DIFF
--- a/utils/installer.py
+++ b/utils/installer.py
@@ -74,9 +74,15 @@ def install_satellite(args):
         provision.rhel_repo_enable(ssh_sat)
         provision.satellite_cdn_pool_attach(ssh_sat)
         provision.satellite_cdn_repo_enable(ssh_sat, sat_ver, rhel_ver)
-    provision.satellite_pkg_install(ssh_sat)
-    provision.satellite_deploy(
-        ssh_sat, admin_username, admin_password, manifest_url, sat_ver)
+    if "nightly" in sat_type:
+        provision.employee_sku_attach(ssh_sat)
+        provision.rhel_repo_enable(ssh_sat)
+        provision.satellite_nightly_deploy(
+            ssh_sat, admin_username, admin_password, manifest_url)
+    else:
+        provision.satellite_pkg_install(ssh_sat)
+        provision.satellite_deploy(
+            ssh_sat, admin_username, admin_password, manifest_url, sat_ver)
     cmd = "rm -f {1}; curl -L {0} -o {1}; sync".format(
         deploy.kubevirt.kube_config_url,
         deploy.kubevirt.kube_config_file)

--- a/virt_who/settings.py
+++ b/virt_who/settings.py
@@ -295,6 +295,11 @@ class SetSatellite(FeatureSettings):
         self.rhel8_compose = None
         self.manifest = None
         self.activation_key = None
+        self.foreman_proxy_dns = None
+        self.foreman_proxy_tftp = None
+        self.katello_proxy_url = None
+        self.katello_proxy_username = None
+        self.katello_proxy_password = None
 
     def read(self, reader):
         self.admin_user = reader.get('satellite', 'admin_user')
@@ -307,6 +312,12 @@ class SetSatellite(FeatureSettings):
         self.rhel8_compose = reader.get('satellite', 'rhel8_compose')
         self.manifest = reader.get('satellite', 'manifest')
         self.activation_key = reader.get('satellite', 'activation_key')
+        self.foreman_proxy_dns = reader.get('satellite', 'foreman_proxy_dns')
+        self.foreman_proxy_tftp = reader.get('satellite', 'foreman_proxy_tftp')
+        self.katello_proxy_url = reader.get('satellite', 'katello_proxy_url')
+        self.katello_proxy_username = reader.get('satellite', 'katello_proxy_username')
+        self.katello_proxy_password = reader.get('satellite', 'katello_proxy_password')
+        
 
 class SetVcenter(FeatureSettings):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
The nightly upstream is deployed by ansible-playbook from forklift repo, now we can support it for virtwho-configure testing.