### PR TITLE
Patch tc 1045 2013

### DIFF
--- a/tests/tier1/tc_1045_check_rhsm_proxy_function_in_rhsm_conf.py
+++ b/tests/tier1/tc_1045_check_rhsm_proxy_function_in_rhsm_conf.py
@@ -42,24 +42,23 @@ class Testcase(Testing):
         try:
             logger.info(">>>step1: set /etc/rhsm/rhsm.conf with good "
                         "proxy_hostname and proxy_port")
-            self.vw_option_update_value("proxy_hostname", proxy_server,
-                                        '/etc/rhsm/rhsm.conf')
-            self.vw_option_update_value("proxy_port", proxy_port,
-                                        '/etc/rhsm/rhsm.conf')
+            self.vw_option_update_value(
+                "proxy_hostname", proxy_server, '/etc/rhsm/rhsm.conf')
+            self.vw_option_update_value("proxy_port", proxy_port, '/etc/rhsm/rhsm.conf')
             data, tty_output, rhsm_output = self.vw_start()
             s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step1', []).append(s1)
-            s2 = self.vw_msg_search(rhsm_output,
-                                    "Connection built.*{0}".format(proxy_server))
+            s2 = self.vw_msg_search(
+                rhsm_output, "Connection built.*{0}".format(proxy_server))
             results.setdefault('step1', []).append(s2)
             s3 = self.vw_msg_search(rhsm_output, "Using proxy.*{0}".format(proxy_server))
             results.setdefault('step1', []).append(s3)
 
             logger.info(">>>step2: set wrong proxy in /etc/rhsm/rhsm.conf")
-            self.vw_option_update_value("proxy_hostname", bad_proxy_server,
-                                        '/etc/rhsm/rhsm.conf')
-            self.vw_option_update_value("proxy_port", bad_proxy_port,
-                                        '/etc/rhsm/rhsm.conf')
+            self.vw_option_update_value(
+                "proxy_hostname", bad_proxy_server, '/etc/rhsm/rhsm.conf')
+            self.vw_option_update_value(
+                "proxy_port", bad_proxy_port, '/etc/rhsm/rhsm.conf')
             data, tty_output, rhsm_output = self.vw_start()
             s1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
             s2 = self.msg_validation(rhsm_output, error_msg, exp_exist=True)
@@ -67,7 +66,8 @@ class Testcase(Testing):
             results.setdefault('step2', []).append(s2)
 
             logger.info(">>>step3: set no_proxy=[server_hostname] in /etc/rhsm/rhsm.conf")
-            self.vw_option_update_value("no_proxy", register_server, '/etc/rhsm/rhsm.conf')
+            self.vw_option_update_value(
+                "no_proxy", register_server, '/etc/rhsm/rhsm.conf')
             data, tty_output, rhsm_output = self.vw_start()
             s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step3', []).append(s1)
@@ -83,8 +83,8 @@ class Testcase(Testing):
                         " in /etc/virt-who.conf")
             self.vw_option_enable('[defaults]', '/etc/virt-who.conf')
             self.vw_option_enable('rhsm_no_proxy', '/etc/virt-who.conf')
-            self.vw_option_update_value('rhsm_no_proxy', register_server,
-                                        '/etc/virt-who.conf')
+            self.vw_option_update_value(
+                'rhsm_no_proxy', register_server, '/etc/virt-who.conf')
             data, tty_output, rhsm_output = self.vw_start()
             s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step5', []).append(s1)

--- a/tests/tier1/tc_1045_check_rhsm_proxy_function_in_rhsm_conf.py
+++ b/tests/tier1/tc_1045_check_rhsm_proxy_function_in_rhsm_conf.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133691')
@@ -18,6 +19,12 @@ class Testcase(Testing):
         config_name = "virtwho-config"
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
+        if "libvirt-local" in hypervisor_type:
+            register_config = self.get_register_config()
+            owner = register_config['owner']
+            cmd = "echo -e '[{0}]\ntype=libvirt\nowner={1}' > {2}".format(
+                config_name, owner, config_file)
+            ret, output = self.runcmd(cmd, self.ssh_host())
         register_config = self.get_register_config()
         register_server = register_config['server']
         register_type = register_config['type']
@@ -28,24 +35,31 @@ class Testcase(Testing):
         proxy_port = "3128"
         bad_proxy_server = "xxx.eng.pek2.redhat.com"
         bad_proxy_port = "0000"
-        error_msg = ["Connection refused|Unable to connect to: .*{0}".format(bad_proxy_server)]
+        error_msg = ["Connection refused|"
+                     "Unable to connect to: .*{0}".format(bad_proxy_server)]
 
         # Case Steps
         try:
-            logger.info(">>>step1: set /etc/rhsm/rhsm.conf with good proxy_hostname and proxy_port")
-            self.vw_option_update_value("proxy_hostname", proxy_server, '/etc/rhsm/rhsm.conf')
-            self.vw_option_update_value("proxy_port", proxy_port, '/etc/rhsm/rhsm.conf')
+            logger.info(">>>step1: set /etc/rhsm/rhsm.conf with good "
+                        "proxy_hostname and proxy_port")
+            self.vw_option_update_value("proxy_hostname", proxy_server,
+                                        '/etc/rhsm/rhsm.conf')
+            self.vw_option_update_value("proxy_port", proxy_port,
+                                        '/etc/rhsm/rhsm.conf')
             data, tty_output, rhsm_output = self.vw_start()
             s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step1', []).append(s1)
-            s2 = self.vw_msg_search(rhsm_output, "Connection built.*{0}".format(proxy_server), exp_exist=True)
+            s2 = self.vw_msg_search(rhsm_output,
+                                    "Connection built.*{0}".format(proxy_server))
             results.setdefault('step1', []).append(s2)
-            s3 = self.vw_msg_search(rhsm_output, "Using proxy.*{0}".format(proxy_server), exp_exist=True)
+            s3 = self.vw_msg_search(rhsm_output, "Using proxy.*{0}".format(proxy_server))
             results.setdefault('step1', []).append(s3)
 
             logger.info(">>>step2: set wrong proxy in /etc/rhsm/rhsm.conf")
-            self.vw_option_update_value("proxy_hostname", bad_proxy_server, '/etc/rhsm/rhsm.conf')
-            self.vw_option_update_value("proxy_port", bad_proxy_port, '/etc/rhsm/rhsm.conf')
+            self.vw_option_update_value("proxy_hostname", bad_proxy_server,
+                                        '/etc/rhsm/rhsm.conf')
+            self.vw_option_update_value("proxy_port", bad_proxy_port,
+                                        '/etc/rhsm/rhsm.conf')
             data, tty_output, rhsm_output = self.vw_start()
             s1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
             s2 = self.msg_validation(rhsm_output, error_msg, exp_exist=True)
@@ -65,10 +79,12 @@ class Testcase(Testing):
             results.setdefault('step4', []).append(s1)
             self.vw_option_update_value("no_proxy", '', '/etc/rhsm/rhsm.conf')
 
-            logger.info(">>>step5: set rhsm_no_proxy=[server_hostname] in /etc/virt-who.conf")
+            logger.info(">>>step5: set rhsm_no_proxy=[server_hostname]"
+                        " in /etc/virt-who.conf")
             self.vw_option_enable('[defaults]', '/etc/virt-who.conf')
             self.vw_option_enable('rhsm_no_proxy', '/etc/virt-who.conf')
-            self.vw_option_update_value('rhsm_no_proxy', register_server, '/etc/virt-who.conf')
+            self.vw_option_update_value('rhsm_no_proxy', register_server,
+                                        '/etc/virt-who.conf')
             data, tty_output, rhsm_output = self.vw_start()
             s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step5', []).append(s1)
@@ -81,7 +97,8 @@ class Testcase(Testing):
             self.vw_option_disable('rhsm_no_proxy', '/etc/virt-who.conf')
 
             if hypervisor_type not in ('libvirt-local', 'vdsm'):
-                logger.info(">>>step7: set rhsm_no_proxy=[server_hostname] in /etc/virt-who.d/x.conf")
+                logger.info(">>>step7: set rhsm_no_proxy=[server_hostname] "
+                            "in /etc/virt-who.d/x.conf")
                 self.vw_option_add('rhsm_no_proxy', register_server, config_file)
                 data, tty_output, rhsm_output = self.vw_start()
                 s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
@@ -96,7 +113,8 @@ class Testcase(Testing):
             else:
                 logger.info('Skip step7 and step8 for {0}'.format(hypervisor_type))
 
-            logger.info(">>>step9: set no_proxy=[server_hostname] in /etc/sysconfig/virt-who")
+            logger.info(">>>step9: set no_proxy=[server_hostname]"
+                        " in /etc/sysconfig/virt-who")
             self.vw_option_add('no_proxy', register_server, '/etc/sysconfig/virt-who')
             data, tty_output, rhsm_output = self.vw_start()
             s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
@@ -119,8 +137,4 @@ class Testcase(Testing):
             self.vw_option_update_value('no_proxy', '', "/etc/rhsm/rhsm.conf")
 
         # case result
-        notes = list()
-        if hypervisor_type in ('libvirt-local', 'vdsm'):
-            notes.append("(step5,6) rhsm_no_proxy doesn't work for local libvirt and vdsm mode")
-            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1720048")
-        self.vw_case_result(results, notes)
+        self.vw_case_result(results)

--- a/tests/tier1/tc_1045_check_rhsm_proxy_function_in_rhsm_conf.py
+++ b/tests/tier1/tc_1045_check_rhsm_proxy_function_in_rhsm_conf.py
@@ -19,18 +19,13 @@ class Testcase(Testing):
         config_name = "virtwho-config"
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
+        register_config = self.get_register_config()
+        register_server = register_config['server']
         if "libvirt-local" in hypervisor_type:
-            register_config = self.get_register_config()
             owner = register_config['owner']
             cmd = "echo -e '[{0}]\ntype=libvirt\nowner={1}' > {2}".format(
                 config_name, owner, config_file)
             ret, output = self.runcmd(cmd, self.ssh_host())
-        register_config = self.get_register_config()
-        register_server = register_config['server']
-        register_type = register_config['type']
-        if "satellite" in register_type:
-            ssh_sat = register_config['ssh_sat']
-            register_server = self.get_hostname(ssh_sat)
         proxy_server = "bootp-73-3-248.eng.pek2.redhat.com"
         proxy_port = "3128"
         bad_proxy_server = "xxx.eng.pek2.redhat.com"

--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -46,10 +46,10 @@ class Testcase(Testing):
             self.vw_option_add(option, value, filename=sysconfig_file)
             data, tty_output, rhsm_output = self.vw_start(exp_send=1)
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-            res2 = self.vw_msg_search(rhsm_output, "Connection built.*{0}"
-                                      .format(good_squid_server))
-            res3 = self.vw_msg_search(rhsm_output, "Using proxy.*{0}"
-                                      .format(good_squid_server))
+            res2 = self.vw_msg_search(
+                rhsm_output, "Connection built.*{0}".format(good_squid_server))
+            res3 = self.vw_msg_search(
+                rhsm_output, "Using proxy.*{0}".format(good_squid_server))
             results.setdefault('step1', []).append(res1)
             results.setdefault('step1', []).append(res2)
             results.setdefault('step1', []).append(res3)
@@ -98,7 +98,8 @@ class Testcase(Testing):
                 '''virt-who connect hypervisor by proxy'''
                 error_msg = "Cannot connect to proxy"
                 data, tty_output, rhsm_output = self.vw_start(exp_send=0, exp_error=True)
-                res3 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
+                res3 = self.op_normal_value(
+                    data, exp_error='1|2', exp_thread=1, exp_send=0)
                 res4 = self.vw_msg_search(rhsm_output, error_msg)
                 logger.info("+++ Configure no_proxy=[hypervisor_server] "
                             "and rhsm_no_proxy=[register_server] +++")

--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -9,6 +9,7 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136709')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] < '0.25.7':
             self.vw_case_skip("virt-who version")
         if hypervisor_type in ('libvirt-local', 'vdsm'):
@@ -19,25 +20,25 @@ class Testcase(Testing):
         results = dict()
         sysconfig_file = "/etc/sysconfig/virt-who"
         vw_conf = "/etc/virt-who.conf"
+        conf_file = "/etc/virt-who.d/virtwho-config.conf"
         self.vw_option_enable('[global]', vw_conf)
         self.vw_option_enable('debug', vw_conf)
         self.vw_option_update_value('debug', 'True', vw_conf)
         self.vw_option_enable('[defaults]', vw_conf)
-        self.vw_etc_d_mode_create('virtwho-config', '/etc/virt-who.d/virtwho-config.conf')
+        self.vw_etc_d_mode_create('virtwho-config', conf_file)
         register_config = self.get_register_config()
         register_server = register_config['server']
         hypervisor_config = self.get_hypervisor_config()
         hypervisor_server = hypervisor_config['ssh_hypervisor']['host']
-        if hypervisor_type == 'rhevm':
-            hypervisor_server = self.get_hostname(hypervisor_config['ssh_hypervisor'])
         good_squid_server = "10.73.3.248:3128"
         wrong_squid_server = "10.73.3.24:3128"
-        types = {'type1':'http_proxy', 'type2':'https_proxy'}
+        types = {'type1': 'http_proxy',
+                 'type2': 'https_proxy'}
 
         # Case Steps
         logger.info(">>>step1: run with good proxy server")
-        for type, option in sorted(types.items(), key=lambda item:item[0]):
-            logger.info(">>%s: run virt-who to check %s" % (type, option))
+        for type, option in sorted(types.items(), key=lambda item: item[0]):
+            logger.info("+++ {0}: run virt-who to check {1} +++".format(type, option))
             if option == "http_proxy":
                 value = "http://{0}".format(good_squid_server)
             if option == "https_proxy":
@@ -45,42 +46,62 @@ class Testcase(Testing):
             self.vw_option_add(option, value, filename=sysconfig_file)
             data, tty_output, rhsm_output = self.vw_start(exp_send=1)
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-            res2 = self.vw_msg_search(rhsm_output, "Connection built.*%s" % good_squid_server)
-            res3 = self.vw_msg_search(rhsm_output, "Using proxy.*%s" % good_squid_server)
+            res2 = self.vw_msg_search(rhsm_output, "Connection built.*{0}"
+                                      .format(good_squid_server))
+            res3 = self.vw_msg_search(rhsm_output, "Using proxy.*{0}"
+                                      .format(good_squid_server))
             results.setdefault('step1', []).append(res1)
             results.setdefault('step1', []).append(res2)
             results.setdefault('step1', []).append(res3)
             self.vw_option_del(option, filename=sysconfig_file)
 
         logger.info(">>>step2: run with bad proxy server and no_proxy")
-        for type, option in sorted(types.items(), key=lambda item:item[0]):
-            logger.info(">>%s: ------ %s test------" % (type, option))
-            logger.info("> run virt-who with bad {0}".format(option))
+        for type, option in sorted(types.items(), key=lambda item: item[0]):
+            logger.info("=== {0}: bad {1} test ===".format(type, option))
+            logger.info("+++ run virt-who with bad {0} +++".format(option))
             if option == "http_proxy":
                 value = "http://{0}".format(wrong_squid_server)
             if option == "https_proxy":
                 value = "https://{0}".format(wrong_squid_server)
             self.vw_option_add(option, value, filename=sysconfig_file)
             data, tty_output, rhsm_output = self.vw_start(exp_send=0, exp_error=True)
-            error_msg = "Connection refused|Cannot connect to proxy|Connection timed out"
+            error_msg = ["Connection refused|"
+                         "Cannot connect to proxy|"
+                         "Connection timed out"]
             res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
-            res2 = self.vw_msg_search(rhsm_output, error_msg)
+            res2 = self.msg_validation(rhsm_output, error_msg)
             results.setdefault('step2', []).append(res1)
             results.setdefault('step2', []).append(res2)
-            logger.info("> configure no_proxy=[register_server] in /etc/sysconfig/virt-who")
+
+            logger.info("+++ configure no_proxy=[register_server] "
+                        "in /etc/sysconfig/virt-who +++")
             self.vw_option_add("no_proxy", register_server, sysconfig_file)
-            if hypervisor_type in ('libvirt-remote', 'hyperv', 'kubevirt'):
-                logger.info("virt-who connect hypervisor '{0}' not by proxy".format(hypervisor_type))
+            if (
+                    (
+                            "RHEL-8" in compose_id and hypervisor_type in (
+                            'libvirt-remote', 'hyperv', 'kubevirt')
+                    ) or
+                    (
+                            "RHEL-7" in compose_id and (
+                            ('http_proxy' in option and hypervisor_type in (
+                            'esx', 'libvirt-remote', 'xen', 'rhevm', 'kubevirt'))
+                            or
+                            ('https_proxy' in option and hypervisor_type in (
+                            'libvirt-remote', 'hyperv', 'kubevirt')))
+                    )
+            ):
+                '''virt-who connect hypervisor not by proxy'''
                 data, tty_output, rhsm_output = self.vw_start(exp_send=1)
                 res3 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
                 results.setdefault('step2', []).append(res3)
             else:
-                logger.info("virt-who connect hypervisor '{0}' by proxy".format(hypervisor_type))
+                '''virt-who connect hypervisor by proxy'''
                 error_msg = "Cannot connect to proxy"
                 data, tty_output, rhsm_output = self.vw_start(exp_send=0, exp_error=True)
                 res3 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
                 res4 = self.vw_msg_search(rhsm_output, error_msg)
-                logger.info("> Configure no_proxy=[hypervisor_server] and rhsm_no_proxy=[register_server]")
+                logger.info("+++ Configure no_proxy=[hypervisor_server] "
+                            "and rhsm_no_proxy=[register_server] +++")
                 self.vw_option_update_value("no_proxy", hypervisor_server, sysconfig_file)
                 self.vw_option_enable("rhsm_no_proxy", vw_conf)
                 self.vw_option_update_value("rhsm_no_proxy", register_server, vw_conf)
@@ -94,9 +115,12 @@ class Testcase(Testing):
             self.vw_option_disable('rhsm_no_proxy', vw_conf)
 
         # Case Result
-        logger.info("WONTFI bz1716337 - virt-who doesn't connect all hypervisors by proxy")
+        '''WONTFI bz1716337 - virt-who doesn't connect all hypervisors by proxy'''
         notes = list()
         if hypervisor_type == 'xen':
-            notes.append("(step2) [XEN] Succeeded to send mapping but always print errors")
-            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1739358")
+            notes.append("(step2) [XEN] Print errors when send mapping")
+            if "RHEL-8" in compose_id:
+                notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1739358")
+            elif "RHEL-7" in compose_id:
+                notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1764004")
         self.vw_case_result(results, notes)

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1393,7 +1393,7 @@ class Provision(Register):
         return sat_ver, rhel_ver
 
     def satellite_cdn_pool_attach(self, ssh_sat):
-        pool_id = "8a99f9a06c534888016c64de986338f8"
+        pool_id = "8a99f9a36df7fa2d016dfbeed744078a"
         sat_host = ssh_sat['host']
         cmd = "subscription-manager subscribe --pool={0}".format(pool_id)
         for i in range(10):

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -587,7 +587,8 @@ class Testing(Provision):
         if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.24.6':
             cf_env = ''
         if mode == "vdsm":
-            cmd = "echo -e '[{0}]\ntype={1}' > {2}".format(config_name, mode, config_file)
+            cmd = "echo -e '[{0}]\ntype={1}\nowner={2}' > {3}".format(
+                config_name, mode, owner, config_file)
         elif mode == "kubevirt":
             cf_kube = 'kubeconfig={0}\n'.format(hypervisor_config['server_config'])
             cmd = ('cat <<EOF > {0}''{1}''{2}''{3}''{4}''{5}''EOF').format(


### PR DESCRIPTION
update tc_2013 because different behavior for rhel7 and rhel8, and bzbz1716337 was closed as wontfix.
update tc_1045 because bz1720048 fixed.
```
================ test session starts ==================
tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py .                                                                              [100%]
============= 1 passed in 409.08 seconds ===================
```
```
============= test session starts ==============
tests/tier1/tc_1045_check_rhsm_proxy_function_in_rhsm_conf.py .                                                                            [100%]
================ 1 passed in 388.83 seconds =====
```