### PR TITLE
add tc_1011 1013 and 1015 back to case library

### DIFF
--- a/tests/tier1/tc_1011_check_virtwho_debug_function_by_sysconfig.py
+++ b/tests/tier1/tc_1011_check_virtwho_debug_function_by_sysconfig.py
@@ -4,22 +4,23 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133662')
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
         self.vw_case_init()
 
         # case config
         results = dict()
-        config_file = "/etc/sysconfig/virt-who"
-        self.vw_etc_sys_mode_enable()
+        sysconf_file = "/etc/sysconfig/virt-who"
+        config_name = "virtwho-config"
+        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+        self.vw_etc_d_mode_create(config_name, config_file)
 
         # case steps
         logger.info('>>>step1: Run virt-who with "VIRTWHO_DEBUG=1"')
-        self.vw_option_enable("VIRTWHO_DEBUG", filename=config_file)
-        self.vw_option_update_value("VIRTWHO_DEBUG", "1", filename=config_file)
+        self.vw_option_enable("VIRTWHO_DEBUG", filename=sysconf_file)
+        self.vw_option_update_value("VIRTWHO_DEBUG", "1", filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         res2 = self.vw_msg_search(output=rhsm_output, msg="\[.*DEBUG\]", exp_exist=True)
@@ -27,7 +28,7 @@ class Testcase(Testing):
         results.setdefault('step1', []).append(res2)
 
         logger.info('>>>step2: Run virt-who with "VIRTWHO_DEBUG=0"')
-        self.vw_option_update_value("VIRTWHO_DEBUG", "0", filename=config_file)
+        self.vw_option_update_value("VIRTWHO_DEBUG", "0", filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         res2 = self.vw_msg_search(output=rhsm_output, msg="\[.*DEBUG\]", exp_exist=False)
@@ -35,7 +36,7 @@ class Testcase(Testing):
         results.setdefault('step2', []).append(res2)
 
         logger.info('>>>step3: Run virt-who with "VIRTWHO_DEBUG" disabled')
-        self.vw_option_disable("VIRTWHO_DEBUG", filename=config_file)
+        self.vw_option_disable("VIRTWHO_DEBUG", filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         res2 = self.vw_msg_search(output=rhsm_output, msg="\[.*DEBUG\]", exp_exist=False)

--- a/tests/tier1/tc_1013_check_virtwho_oneshot_function_by_sysconfig.py
+++ b/tests/tier1/tc_1013_check_virtwho_oneshot_function_by_sysconfig.py
@@ -4,34 +4,35 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133651')
-        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.23.3':
-            self.vw_case_skip("virt-who version")
         self.vw_case_init()
 
         # case config
         results = dict()
-        config_file = "/etc/sysconfig/virt-who"
-        self.vw_etc_sys_mode_enable()        
+        sysconf_file = "/etc/sysconfig/virt-who"
+        config_name = "virtwho-config"
+        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+        self.vw_etc_d_mode_create(config_name, config_file)
 
         # case steps
         logger.info('>>>step1: Run virt-who with "VIRTWHO_ONE_SHOT=1"')
-        self.vw_option_enable("VIRTWHO_ONE_SHOT", filename=config_file)
-        self.vw_option_update_value("VIRTWHO_ONE_SHOT", "1", filename=config_file)
+        self.vw_option_enable("VIRTWHO_ONE_SHOT", filename=sysconf_file)
+        self.vw_option_update_value("VIRTWHO_ONE_SHOT", "1", filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1, oneshot=True)
         res = self.op_normal_value(data, exp_error=0, exp_thread=0, exp_send=1)
         results.setdefault('step1', []).append(res)
 
         logger.info('>>>step2: Run virt-who with "VIRTWHO_ONE_SHOT=0"')
-        self.vw_option_update_value("VIRTWHO_ONE_SHOT", "0", filename=config_file)
+        self.vw_option_update_value("VIRTWHO_ONE_SHOT", "0", filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1, oneshot=False)
         res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step2', []).append(res)
 
         logger.info('>>>step3: Run virt-who with "VIRTWHO_ONE_SHOT" disabled')
-        self.vw_option_disable("VIRTWHO_ONE_SHOT", filename=config_file)
+        self.vw_option_disable("VIRTWHO_ONE_SHOT", filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1, oneshot=False)
         res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step3', []).append(res)

--- a/tests/tier1/tc_1015_check_interval_function_by_etc_sysconfig.py
+++ b/tests/tier1/tc_1015_check_interval_function_by_etc_sysconfig.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133655')
@@ -12,37 +13,43 @@ class Testcase(Testing):
         # case config
         results = dict()
         option_tested = "VIRTWHO_INTERVAL"
-        config_file = "/etc/sysconfig/virt-who"
-        self.vw_option_enable("VIRTWHO_DEBUG", filename=config_file)
-        self.vw_option_update_value("VIRTWHO_DEBUG", '1', filename=config_file)
-        self.vw_etc_d_mode_create('virtwho-config', "/etc/virt-who.d/virtwho-config.conf")
+        sysconf_file = "/etc/sysconfig/virt-who"
+        self.vw_option_enable("VIRTWHO_DEBUG", filename=sysconf_file)
+        self.vw_option_update_value("VIRTWHO_DEBUG", '1', filename=sysconf_file)
+        config_name = "virtwho-config"
+        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+        self.vw_etc_d_mode_create(config_name, config_file)
 
         # case steps
         logger.info(">>>step1: disable VIRTWHO_INTERVAL option")
-        self.vw_option_disable(option_tested, filename=config_file)
+        self.vw_option_disable(option_tested, filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
-        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=3600)
+        res = self.op_normal_value(
+            data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=3600)
         results.setdefault('step1', []).append(res)
 
         logger.info(">>>step2: enable VIRTWHO_INTERVAL and set to 10")
-        self.vw_option_enable(option_tested, filename=config_file)
-        self.vw_option_update_value(option_tested, '10', filename=config_file)
+        self.vw_option_enable(option_tested, filename=sysconf_file)
+        self.vw_option_update_value(option_tested, '10', filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
-        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=3600)
+        res = self.op_normal_value(
+            data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=3600)
         results.setdefault('step2', []).append(res)
 
         logger.info(">>>step3: enable VIRTWHO_INTERVAL and set to 60")
-        self.vw_option_enable(option_tested, filename=config_file)
-        self.vw_option_update_value(option_tested, '60', filename=config_file)
+        self.vw_option_update_value(option_tested, '60', filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1, exp_loopnum=1)
-        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=60, exp_loopnum=1, exp_looptime=60)
+        res = self.op_normal_value(
+            data, exp_error=0, exp_thread=1, exp_send=1,
+            exp_interval=60, exp_loopnum=1, exp_looptime=60)
         results.setdefault('step3', []).append(res)
 
         logger.info(">>>step4: enable VIRTWHO_INTERVAL and set to 120")
-        self.vw_option_enable(option_tested, filename=config_file)
-        self.vw_option_update_value(option_tested, '120', filename=config_file)
+        self.vw_option_update_value(option_tested, '120', filename=sysconf_file)
         data, tty_output, rhsm_output = self.vw_start(exp_send=1, exp_loopnum=1)
-        res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1, exp_interval=120, exp_loopnum=1, exp_looptime=120)
+        res = self.op_normal_value(
+            data, exp_error=0, exp_thread=1, exp_send=1,
+            exp_interval=120, exp_loopnum=1, exp_looptime=120)
         results.setdefault('step4', []).append(res)
 
         # case result


### PR DESCRIPTION
The debug, oneshot and interval options are still available in /etc/sysconfig/virt-who, so we can test them by configuring hypervisors by /etc/virt-who.d/.

```
=================== test session starts ====================
tests/tier1/tc_1011_check_virtwho_debug_function_by_sysconfig.py .                                                       [ 33%]
tests/tier1/tc_1013_check_virtwho_oneshot_function_by_sysconfig.py .                                                     [ 66%]
tests/tier1/tc_1015_check_interval_function_by_etc_sysconfig.py .                                                        [100%]

==================3 passed in 814.43 seconds ================
```