### PR TITLE
Add 6.7 support to Sat-provision

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1434,6 +1434,8 @@ class Provision(Register):
             cmd = "yum -y localinstall {0}".format(repo)
             ret, output = self.runcmd(cmd, ssh_sat, desc="install katello-ca")
             cmd = "subscription-manager register --org Sat6-CI --activationkey '%s-%s.0-qa-rhel%s'" % (repo_type, sat_ver, rhel_ver)
+            if sat_ver == "6.7":
+                cmd = "subscription-manager register --org Sat6-CI --activationkey '%s-%s-qa-rhel%s'" % (repo_type, sat_ver, rhel_ver)
             ret, output = self.runcmd(cmd, ssh_sat, desc="register and enable repo")
             if ret == 0:
                 cmd = "subscription-manager attach --pool 8a88800f5ca45116015cc807610319ed"

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1368,7 +1368,9 @@ class Provision(Register):
         return job_passed
 
     def satellite_version(self, sat_type):
-        if "6.6" in sat_type or "66" in sat_type:
+        if "6.7" in sat_type or "67" in sat_type:
+            sat_ver = "6.7"
+        elif "6.6" in sat_type or "66" in sat_type:
             sat_ver = "6.6"
         elif "6.5" in sat_type or "65" in sat_type:
             sat_ver = "6.5"


### PR DESCRIPTION
Add version 6.7 support to Satellite-provision

**support command :**
python3 installer.py install-satellite --host=[sathost] --username=[username] --password=[pwd] --sat-release=[sat-release] --sat-repo=dogfood --sat-os=[sat-os]

**highlight**
when registering in Sat-6.7:
the activationkey in the command `subscription-manager register --org Sat6-CI --activationkey 'satellite-6.7-qa-rhel7'` missing ".0" 
