### PR TITLE
Fix Sat 6.7 deployed error

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1468,7 +1468,7 @@ class Provision(Register):
             manifest_filename = "{0}/{1}".format(manifest_path, output.strip())
         else:
             raise FailException("No manifest file found")
-        if sat_ver == "6.6":
+        if sat_ver >= "6.6":
             options = "--disable-system-checks --foreman-initial-admin-password={0}".format(admin_passwd)
         else:
             options = "--disable-system-checks --foreman-admin-password={0}".format(admin_passwd)


### PR DESCRIPTION

**Description**
Sat 6.7 deployed failed due to the following error:
```
[root@ent-02-vm-03 ~]# satellite-installer --scenario satellite --disable-system-checks --foreman-admin-password=admin
ERROR: Unrecognised option '--foreman-admin-password'

See: 'satellite-installer --help'
```

**Solution**
from 6.6, we start to use `--foreman-initial-admin-password` instead