### PR TITLE
update vw_case_skip()

### DIFF
--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -435,13 +435,7 @@ class Testing(Provision):
             self.pkg_install(self.ssh_host(), 'virt-who')
 
     def vw_case_skip(self, skip_reason=None):
-        try:
-            self.skipTest("SkipTest, not avaialbe for {0}".format(skip_reason))
-        except:
-            logger.info(str(SkipTest))
-            raise SkipTest
-        finally:
-            logger.info("Succeeded to skip case\n")
+        self.skipTest("Succeeded to skip case, not avaialbe for {0}".format(skip_reason))
 
     def vw_case_result(self, results, notes=None):
         for key, value in results.items():


### PR DESCRIPTION
Simplify function vw_case_skip()

```
# nosetests-3 -v tests/tier3/tc_1027_check_two_modes_enabled_in_etc_sysconfig.py
2019-11-21 10:08:45 [INFO] RHEL-133743:tc_1027_check_two_modes_enabled_in_etc_sysconfig.py
SKIP: Succeeded to skip case, not avaialbe for virt-who version

----------------------------------------------------------------------
Ran 1 test in 3.153s

OK (SKIP=1)

```