### PR TITLE
change has_key()

### DIFF
--- a/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
@@ -44,7 +44,7 @@ class Testcase(Testing):
                 hypervisorId = host_name
             else:
                 hypervisorId = host_uuid
-            if data[register_owner].has_key(hypervisorId):
+            if hypervisorId in data[register_owner].keys():
                 logger.info("Succeeded to search hypervisorId:{0}".format(hypervisorId))
                 results.setdefault(step, []).append(True)
             else:

--- a/tests/tier1/tc_1053_check_hypervisor_id_and_filter_hosts_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1053_check_hypervisor_id_and_filter_hosts_option_in_etc_virtwho_d.py
@@ -46,7 +46,7 @@ class Testcase(Testing):
             s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault(step, []).append(s1)
             hypervisor_num = data[register_owner]['hypervisor_num']
-            if data[register_owner].has_key(hypervisorId) and hypervisor_num == 1:
+            if hypervisorId in data[register_owner].keys() and hypervisor_num == 1:
                 logger.info("Succeeded to search, {0} hypervisorId({1}) found".format(hypervisor_num, hypervisorId))
                 results.setdefault(step, []).append(True)
             else:

--- a/tests/tier1/tc_1067_check_defaults_hypervisor_id_option_in_etc_virtwho_conf.py
+++ b/tests/tier1/tc_1067_check_defaults_hypervisor_id_option_in_etc_virtwho_conf.py
@@ -47,7 +47,7 @@ class Testcase(Testing):
                 hypervisorId = host_name
             else:
                 hypervisorId = host_uuid
-            if data[register_owner].has_key(hypervisorId):
+            if hypervisorId in data[register_owner].keys():
                 logger.info("Succeeded to search hypervisorId:{0}".format(hypervisorId))
                 results.setdefault(step, []).append(True)
             else:

--- a/tests/tier1/tc_1073_check_mapping_info_point_to_specified_owner.py
+++ b/tests/tier1/tc_1073_check_mapping_info_point_to_specified_owner.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133683')
@@ -30,11 +31,13 @@ class Testcase(Testing):
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
         res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step1', []).append(res)
-        if data.has_key(register_owner) and data[register_owner].has_key(guest_uuid):
-            logger.info("Succeeded to check, mapping info is specified to {0}".format(register_owner))
+        if register_owner in data.keys() and guest_uuid in data[register_owner].keys():
+            logger.info("Succeeded to check, mapping info is specified to {0}".format(
+                register_owner))
             results.setdefault('step1', []).append(True)
         else:
-            logger.error("Failed to check, mapping info is not specified to {0}".format(register_owner))
+            logger.error("Failed to check, mapping info is not specified to {0}".format(
+                register_owner))
             results.setdefault('step1', []).append(False)
 
         # case result

--- a/tests/tier1/tc_1074_check_mapping_info_for_hypervisor_facts.py
+++ b/tests/tier1/tc_1074_check_mapping_info_for_hypervisor_facts.py
@@ -4,6 +4,7 @@ from virt_who.base import Base
 from virt_who.register import Register
 from virt_who.testing import Testing
 
+
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134056')
@@ -32,14 +33,15 @@ class Testcase(Testing):
         logger.info(">>>step1: Run virt-who servie to check hypervisor's facts")
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
         res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+        facts = data[register_owner][host_uuid]
         results.setdefault('step1', []).append(res)
         results.setdefault('step1', []).append(data['is_async'] == "hypervisors_async")
-        results.setdefault('step1', []).append(data[register_owner][host_uuid].has_key('type'))
-        results.setdefault('step1', []).append(data[register_owner][host_uuid].has_key('version'))
-        results.setdefault('step1', []).append(data[register_owner][host_uuid].has_key('socket'))
-        logger.info("hypervisor.type: {0} ".format(data[register_owner][host_uuid]['type']))
-        logger.info("cpu.cpu_socket(s): {0}".format(data[register_owner][host_uuid]['socket']))
-        logger.info("hypervisor.version: {0}".format(data[register_owner][host_uuid]['version']))
+        results.setdefault('step1', []).append('type' in facts.keys())
+        results.setdefault('step1', []).append('version' in facts.keys())
+        results.setdefault('step1', []).append('socket' in facts.keys())
+        logger.info("hypervisor.type: {0} ".format(facts['type']))
+        logger.info("cpu.cpu_socket(s): {0}".format(facts['socket']))
+        logger.info("hypervisor.version: {0}".format(facts['version']))
 
         # case result
         self.vw_case_result(results)

--- a/tests/tier1/tc_1108_check_hypervisor_facts.py
+++ b/tests/tier1/tc_1108_check_hypervisor_facts.py
@@ -50,7 +50,7 @@ class Testcase(Testing):
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step1', []).append(res1)
-        if data[register_owner].has_key(host_uuid):
+        if host_uuid in data[register_owner].keys():
             facts_dic = data[register_owner][host_uuid]
             logger.info("succeeded to get hypervisor facts dict: {0}".format(facts_dic))
             results.setdefault('step1', []).append(True)
@@ -59,7 +59,7 @@ class Testcase(Testing):
 
         logger.info(">>>step2: check all facts item exiting")
         for item in facts_items:
-            if facts_dic.has_key(item) and facts_dic[item] is not None:
+            if item in facts_dic.keys() and facts_dic[item] is not None:
                 logger.info("succeeded to check {0}={1} in {2} facts"
                             .format(item, facts_dic[item], hypervisor_type))
                 results.setdefault('step2', []).append(True)

--- a/tests/tier2/tc_2041_validate_default_hypervisor_id_by_virtwho_conf.py
+++ b/tests/tier2/tc_2041_validate_default_hypervisor_id_by_virtwho_conf.py
@@ -36,7 +36,7 @@ class Testcase(Testing):
         data, tty_output, rhsm_output = self.vw_start(exp_send=1)
         res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step', []).append(res)
-        if data[register_owner].has_key(host_name):
+        if host_name in data[register_owner].keys():
             logger.info("Succeeded to search hypervisorId:{0}".format(host_name))
             results.setdefault('step', []).append(True)
         else:

--- a/tests/tier2/tc_2046_check_registered_by_item_in_satellite_webui.py
+++ b/tests/tier2/tc_2046_check_registered_by_item_in_satellite_webui.py
@@ -56,7 +56,7 @@ class Testcase(Testing):
                                                   guest_name, guest_uuid, "get guest info")
             if output is not None:
                 user = output["subscription_facet_attributes"]["user"]
-                if user is not False and user is not None and user.has_key('login'):
+                if user is not False and user is not None and 'login' in user.keys():
                     registered_by = user['login']
                     if registered_by == exp:
                         logger.info("succeded to check registered_by is '{}'".format(exp))

--- a/tests/tier2/tc_2053_validate_guest_state_when_suspend_resume_stop_start.py
+++ b/tests/tier2/tc_2053_validate_guest_state_when_suspend_resume_stop_start.py
@@ -104,9 +104,9 @@ class Testcase(Testing):
         hypervisor_type = self.get_config('hypervisor_type')
         if exp_state is False:
             if hypervisor_type in ('libvirt-local', 'vdsm'):
-                state = data.has_key(guest_uuid)
+                state = guest_uuid in data.keys()
             else:
-                state = data[owner].has_key(guest_uuid)
+                state = guest_uuid in data[owner].keys()
         else:
             if hypervisor_type in ('libvirt-local', 'vdsm'):
                 state = data[guest_uuid]['state']


### PR DESCRIPTION
dict.has_key() is not suggested, so change to "key in dict.keys()".

```
===========================
pytest result

tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py .     [ 11%]
tests/tier1/tc_1053_check_hypervisor_id_and_filter_hosts_option_in_etc_virtwho_d.py .  [ 22%]
tests/tier1/tc_1067_check_defaults_hypervisor_id_option_in_etc_virtwho_conf.py .   [ 33%]
tests/tier1/tc_1073_check_mapping_info_point_to_specified_owner.py .        [ 44%]
tests/tier1/tc_1074_check_mapping_info_for_hypervisor_facts.py .     [ 55%]
tests/tier1/tc_1108_check_hypervisor_facts.py .      [ 66%]
tests/tier2/tc_2041_validate_default_hypervisor_id_by_virtwho_conf.py .   [ 77%]
tests/tier2/tc_2046_check_registered_by_item_in_satellite_webui.py s     [ 88%]
tests/tier2/tc_2053_validate_guest_state_when_suspend_resume_stop_start.py .   [100%]
========== 8 passed, 1 skipped, 30 warnings in 2422.43 seconds ==============

```