### PR TITLE
fix python3 compatibility issue in polarion_import.py

### DIFF
--- a/scripts/polarion_importer.py
+++ b/scripts/polarion_importer.py
@@ -34,7 +34,7 @@ def get_exported_param(param_name):
 
 def write_file(filename, content):
     try:
-        fd = open(filename,'w')
+        fd = open(filename, 'wb')
         fcntl.flock(fd, fcntl.LOCK_EX)
         fd.write(content.encode("UTF-8"))
         fcntl.flock(fd, fcntl.LOCK_UN)
@@ -62,8 +62,7 @@ def fomatTree(elem):
     root_str = ET.tostring(elem, 'UTF-8')
     reparse = minidom.parseString(root_str)
     return reparse.toprettyxml(
-            encoding = "utf-8"
-            ).replace("\t\t\n", "").replace("\t\n", "").replace("\n\n", "\n")
+        ).replace("\t\t\n", "").replace("\t\n", "").replace("\n\n", "\n")
 
 def xml_init(xmlFile, root_node):
     if os.path.exists(xmlFile):


### PR DESCRIPTION
fix below python3 compatibility issue in polarion_import.py

```
Traceback (most recent call last):
  File "polarion_importer.py", line 215, in <module>
    xml_file, testrun_id = polarion_xml_init()
  File "polarion_importer.py", line 116, in polarion_xml_init
    xml_init(xml_file, "testsuites")
  File "polarion_importer.py", line 74, in xml_init
    write_file(xmlFile, fomatTree(node))
  File "polarion_importer.py", line 67, in fomatTree
    ).replace("\t\t\n", "").replace("\t\n", "").replace("\n\n", "\n")
TypeError: a bytes-like object is required, not 'str
```