### PR TITLE
add exception for write file

### DIFF
--- a/virt_who/base.py
+++ b/virt_who/base.py
@@ -101,7 +101,11 @@ class Base(unittest.TestCase):
         fd.write("Command: {0}\n".format(str(cmd)))
         fd.write("Retcode: {0}\n".format(retcode))
         if debug or retcode != 0:
-            fd.write("Output:\n{0}\n".format(str(stdout)))
+            try:
+                fd.write("Output:\n{0}\n".format(str(stdout)))
+            except:
+                fd.write("Output:\n{0}\n".format(str(stdout.encode("utf-8"))))
+                pass
         fd.close()
         return retcode, stdout.strip()
 


### PR DESCRIPTION
This patch will add an exception when writing data to a file, because you may get the error message as:
```
Traceback (most recent call last):
  File "/root/eko/virtwho-ci/tests/tier1/tc_1008_check_virtwho_fetch_and_send_function_by_virtwho_d.py", line 10, in test_run
    self.vw_case_init()
  File "/root/eko/virtwho-ci/virt_who/testing.py", line 459, in vw_case_init
    self.ssh_no_passwd_access(self.ssh_host(), ssh_hypervisor)
  File "/root/eko/virtwho-ci/virt_who/base.py", line 222, in ssh_no_passwd_access
    ret, output = self.runcmd(cmd, ssh_remote, desc="copy id_rsa.pub to remote")
  File "/root/eko/virtwho-ci/virt_who/base.py", line 104, in runcmd
    fd.write("Output:\n{0}\n".format(str(stdout)))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018' in position 31: ordinal not in range(128)
```