### PR TITLE
fix indexError

### DIFF
--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -826,8 +826,8 @@ class Testing(Provision):
 
     def vw_local_mode_log(self, data, rhsm_output):
         key = "Domain info:"
-        rex = re.compile(r'(?<=Domain info: )\[.*?\]\n+(?=201|$)', re.S)
-        mapping_info = rex.findall(rhsm_output)[-1]
+        rex = re.compile(r'(?<=Domain info: )\[.*?\]\n+(?=\d\d\d\d|$)', re.S)
+        mapping_info = rex.findall(rhsm_output)[0]
         try:
             mapping_info = json.loads(mapping_info.replace('\n', ''), strict=False)
         except:


### PR DESCRIPTION
fix below error:
```
Traceback (most recent call last):
  File "/root/workspace/virtwho-ci/tests/tier1/tc_1008_check_virtwho_fetch_and_send_function_by_virtwho_d.py", line 25, in test_run
    data, tty_output, rhsm_output = self.vw_start(exp_send=1)
  File "/root/workspace/virtwho-ci/virt_who/testing.py", line 1132, in vw_start
    data = self.vw_log_analyzer(data, tty_output, rhsm_output)
  File "/root/workspace/virtwho-ci/virt_who/testing.py", line 857, in vw_log_analyzer
    data = self.vw_local_mode_log(data, rhsm_output)
  File "/root/workspace/virtwho-ci/virt_who/testing.py", line 830, in vw_local_mode_log
    mapping_info = rex.findall(rhsm_output)[-1]
IndexError: list index out of range
```

Test result:
```
# pytest tests/tier1/tc_1008_check_virtwho_fetch_and_send_function_by_virtwho_d.py tests/tier1/tc_1011_check_virtwho_debug_function_by_sysconfig.py tests/tier1/tc_1015_check_interval_function_by_etc_sysconfig.py 
==================== test session starts ===================
platform linux2 -- Python 2.7.15, pytest-3.6.4, py-1.5.4, pluggy-0.6.0
rootdir: /root/workspace/virtwho-ci, inifile:
collected 3 items                                                                                                                                

tests/tier1/tc_1008_check_virtwho_fetch_and_send_function_by_virtwho_d.py .                                                                [ 33%]
tests/tier1/tc_1011_check_virtwho_debug_function_by_sysconfig.py .                                                                         [ 66%]
tests/tier1/tc_1015_check_interval_function_by_etc_sysconfig.py .                                                                          [100%]
=============== 3 passed in 698.09 seconds ==============
```