### PR TITLE
update tc_2019/2025

### DIFF
--- a/tests/tier2/tc_2019_validate_username_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2019_validate_username_option_in_etc_virtwho_d.py
@@ -45,23 +45,31 @@ class Testcase(Testing):
         results.setdefault('step2', []).append(res2)
 
         logger.info(">>>step3: username option is 红帽€467aa value")
-        pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
+        msg_list = ["Unable to login|"
+                    "incorrect user.*|"
+                    "Authentication failure|"
+                    "Incorrect.*username|"
+                    "Unauthorized|"
+                    "Error.* backend|"
+                    "Permission denied"]
         self.vw_option_update_value(option_tested, '红帽€467aa', config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        if pkg[16:21] >= '2.20':
-            msg_list = ["Unable to login|"
-                        "incorrect user.*|"
-                        "Authentication failure|"
-                        "Incorrect.*username|"
-                        "Unauthorized|"
-                        "Error.* backend|"
-                        "Permission denied"]
-            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
-            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-7" in compose_id:
+            pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
+            if pkg[16:21] >= '2.20':
+                res1 = self.op_normal_value(
+                    data, exp_error="1|2|3", exp_thread=1, exp_send=0)
+                res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+            else:
+                msg = "not in latin1 encoding"
+                res1 = self.op_normal_value(
+                    data, exp_error="1|2|3", exp_thread=0, exp_send=0)
+                res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
         else:
-            msg = "not in latin1 encoding"
-            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=0, exp_send=0)
-            res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
+            res1 = self.op_normal_value(
+                data, exp_error="1|2|3", exp_thread=1, exp_send=0)
+            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step3', []).append(res1)
         results.setdefault('step3', []).append(res2)
 

--- a/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
@@ -51,18 +51,26 @@ class Testcase(Testing):
 
         logger.info(">>>step3: run virt-who with rhsm_username=红帽©¥®ðπ∉")
         '''红帽©¥®ðπ∉ username is not supported by candlepin'''
-        pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
+        msg_list = ["codec can't decode|"
+                    "Communication with subscription manager failed"]
         self.vw_option_update_value("rhsm_username", "红帽©¥®ðπ∉", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        if pkg[16:21] >= '2.20':
-            msg_list = ["codec can't decode|"
-                        "Communication with subscription manager failed"]
-            res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
-            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-7" in compose_id:
+            pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
+            if pkg[16:21] >= '2.20':
+                res1 = self.op_normal_value(
+                    data, exp_error="1|2", exp_thread=1, exp_send=0)
+                res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+            else:
+                msg = "not in latin1 encoding"
+                res1 = self.op_normal_value(
+                    data, exp_error="1|2", exp_thread=0, exp_send=0)
+                res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
         else:
-            msg = "not in latin1 encoding"
-            res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=0, exp_send=0)
-            res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
+            res1 = self.op_normal_value(
+                data, exp_error="1|2", exp_thread=1, exp_send=0)
+            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step3', []).append(res1)
         results.setdefault('step3', []).append(res2)
 


### PR DESCRIPTION
The behaviors are different for rhel7 and 8 when run virt-who with username containing unicode characters .
```
# pytest tests/tier2/tc_2019_validate_username_option_in_etc_virtwho_d.py tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py 
================= test session starts =================
platform linux2 -- Python 2.7.15, pytest-3.6.4, py-1.5.4, pluggy-0.6.0
rootdir: /root/workspace/virtwho-ci, inifile:
collected 2 items                                                                                                                                

tests/tier2/tc_2019_validate_username_option_in_etc_virtwho_d.py .                                                                         [ 50%]
tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py .                                                                    [100%]
================ 2 passed in 717.95 seconds ==============
```