### PR TITLE
update tc_2018 due to bz1727203 fixed

### DIFF
--- a/tests/tier2/tc_2018_validate_server_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2018_validate_server_option_in_etc_virtwho_d.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136589')
+        compose_id = self.get_config('rhel_compose')
         hypervisor_type = self.get_config('hypervisor_type')
         if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
             self.vw_case_skip(hypervisor_type)
@@ -31,7 +32,10 @@ class Testcase(Testing):
         logger.info(">>>step2: server option is wrong value")
         self.vw_option_update_value(option_tested, "xxxxxx", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["Name or service not known|Connection timed out|Failed to connect|Error in .* backend"]
+        msg_list = ["Name or service not known|"
+                    "Connection timed out|"
+                    "Failed to connect|"
+                    "Error in .* backend"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step2', []).append(res1)
@@ -40,9 +44,19 @@ class Testcase(Testing):
         logger.info(">>>step3: server option is 红帽€467aa value")
         self.vw_option_update_value(option_tested, '红帽€467aa', config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        msg_list = ["Name or service not known|Connection timed out|Failed to connect|Error in .* backend|Unable to connect|Unable to login"]
-        res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
-        res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        if "RHEL-8" in compose_id and "esx" in hypervisor_type:
+            msg = "Option server needs to be ASCII characters only"
+            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=0, exp_send=0)
+            res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
+        else:
+            msg_list = ["Name or service not known|"
+                        "Connection timed out|"
+                        "Failed to connect|"
+                        "Error in .* backend|"
+                        "Unable to connect|"
+                        "Unable to login"]
+            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
+            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step3', []).append(res1)
         results.setdefault('step3', []).append(res2)
  
@@ -51,7 +65,10 @@ class Testcase(Testing):
         data, tty_output, rhsm_output = self.vw_start()
         if "libvirt-remote" in hypervisor_type:
             logger.warning("libvirt-local mode will be used to instead when server option is null for libvirt-remote")
-            msg_list = ["Name or service not known|Connection timed out|Failed to connect|Error in .* backend"]
+            msg_list = ["Name or service not known|"
+                        "Connection timed out|"
+                        "Failed to connect|"
+                        "Error in .* backend"]
             res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         else:
@@ -66,7 +83,10 @@ class Testcase(Testing):
         data, tty_output, rhsm_output = self.vw_start()
         if "libvirt-remote" in hypervisor_type:
             logger.warning("libvirt-local mode will be used to instead when server option is disabled for libvirt-remote")
-            msg_list = ["Name or service not known|Connection timed out|Failed to connect|Error in .* backend"]
+            msg_list = ["Name or service not known|"
+                        "Connection timed out|"
+                        "Failed to connect|"
+                        "Error in .* backend"]
             res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         else:
@@ -92,7 +112,10 @@ class Testcase(Testing):
         self.vw_option_enable(option_tested, config_file)
         self.vw_option_update_value(option_tested, '', config_file)
         data, tty_output, rhsm_output = self.vw_start(exp_error=True)
-        msg_list = ["SERVER.* not set|Error in .* backend|No host supplied|server needs to be set"]
+        msg_list = ["SERVER.* not set|"
+                    "Error in .* backend|"
+                    "No host supplied|"
+                    "server needs to be set"]
         res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=1)
         res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step7', []).append(res1)


### PR DESCRIPTION
Based on bz1727203, esx mode  behavior in rhel8 is different with other hypervisors when configure server option with unicode characters.

```
# pytest tests/tier2/tc_2018_validate_server_option_in_etc_virtwho_d.py
=================== test session starts ===================
tests/tier2/tc_2018_validate_server_option_in_etc_virtwho_d.py .                                                                           [100%]

================= 1 passed in 375.74 seconds =================
```