### PR TITLE
Update tc_2005 and tc_2020 due to bz1780467 fixed

### DIFF
--- a/tests/tier2/tc_2005_validate_password_option_by_cli.py
+++ b/tests/tier2/tc_2005_validate_password_option_by_cli.py
@@ -52,28 +52,15 @@ class Testcase(Testing):
             results.setdefault('step2', []).append(res2)
 
         logger.info(">>>step3: password option is 红帽€467aa value")
-        pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
         cli = self.vw_cli_base_update(base_cli,
                                       "--{0}-password=.*".format(hypervisor_type),
                                       "--{0}-password=红帽€467aa".format(hypervisor_type))
+        msg = "'password': is not in latin1 encoding"
         data, tty_output, rhsm_output = self.vw_start(cli)
-        if pkg[16:21] >= '2.20':
-            if "libvirt" in hypervisor_type:
-                logger.warning("libvirt-remote can use sshkey to connect, "
-                               "password value is not necessary")
-                res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-                results.setdefault('step2', []).append(res1)
-            else:
-                res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
-                res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
-                results.setdefault('step3', []).append(res1)
-                results.setdefault('step3', []).append(res2)
-        else:
-            msg = "'password': is not in latin1 encoding"
-            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=0, exp_send=0)
-            res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
-            results.setdefault('step3', []).append(res1)
-            results.setdefault('step3', []).append(res2)
+        res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=0, exp_send=0)
+        res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
+        results.setdefault('step3', []).append(res1)
+        results.setdefault('step3', []).append(res2)
 
         logger.info(">>>step4: password option is null value")
         cli = self.vw_cli_base_update(base_cli,

--- a/tests/tier2/tc_2005_validate_password_option_by_cli.py
+++ b/tests/tier2/tc_2005_validate_password_option_by_cli.py
@@ -52,18 +52,26 @@ class Testcase(Testing):
             results.setdefault('step2', []).append(res2)
 
         logger.info(">>>step3: password option is 红帽€467aa value")
+        pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
         cli = self.vw_cli_base_update(base_cli,
                                       "--{0}-password=.*".format(hypervisor_type),
                                       "--{0}-password=红帽€467aa".format(hypervisor_type))
         data, tty_output, rhsm_output = self.vw_start(cli)
-        if "libvirt" in hypervisor_type:
-            logger.warning("libvirt-remote can use sshkey to connect, "
-                           "password value is not necessary")
-            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-            results.setdefault('step2', []).append(res1)
+        if pkg[16:21] >= '2.20':
+            if "libvirt" in hypervisor_type:
+                logger.warning("libvirt-remote can use sshkey to connect, "
+                               "password value is not necessary")
+                res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+                results.setdefault('step2', []).append(res1)
+            else:
+                res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
+                res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+                results.setdefault('step3', []).append(res1)
+                results.setdefault('step3', []).append(res2)
         else:
-            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
-            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+            msg = "'password': is not in latin1 encoding"
+            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=0, exp_send=0)
+            res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
             results.setdefault('step3', []).append(res1)
             results.setdefault('step3', []).append(res2)
 
@@ -102,9 +110,5 @@ class Testcase(Testing):
             results.setdefault('step5', []).append(res2)
 
         # Case Result
-        notes = list()
-        if "rhevm" in hypervisor_type:
-            notes.append("Bug(Step3): username and password are not allowed")
-            notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1751624")
-        self.vw_case_result(results, notes)
+        self.vw_case_result(results)
 

--- a/tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py
@@ -53,8 +53,6 @@ class Testcase(Testing):
         data, tty_output, rhsm_output = self.vw_start()
         compose_id = self.get_config('rhel_compose')
         if "RHEL-7" in compose_id:
-            pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
-        if "RHEL-7" in compose_id and pkg[16:21] < '2.20':
             msg = "'password': is not in latin1 encoding"
             res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=0, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)

--- a/tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py
@@ -21,6 +21,13 @@ class Testcase(Testing):
         config_name = "virtwho-config"
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_etc_d_mode_create(config_name, config_file)
+        msg_list = ["Unable to login|"
+                    "incorrect user.*|"
+                    "Authentication failure|"
+                    "Incorrect.*username|"
+                    "Unauthorized|"
+                    "Error.* backend|"
+                    "Permission denied"]
 
         # Case Steps
         logger.info(">>>step1: password option is good value")
@@ -36,7 +43,6 @@ class Testcase(Testing):
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step2', []).append(res1)
         else:
-            msg_list = ["Unable to login|incorrect user.*|Authentication failure|Incorrect.*username|Unauthorized|Error.* backend|Permission denied"]
             res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
             res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
             results.setdefault('step2', []).append(res1)
@@ -45,16 +51,25 @@ class Testcase(Testing):
         logger.info(">>>step3: password option is 红帽€467aa value")
         self.vw_option_update_value(option_tested, '红帽€467aa', config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        if "libvirt-remote" in hypervisor_type:
-            logger.warning("libvirt-remote can use sshkey to connect, password value is not necessary")
-            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-            results.setdefault('step2', []).append(res1)
-        else:
-            msg_list = ["Unable to login|incorrect user.*|Authentication failure|Incorrect.*username|Unauthorized|Error.* backend|Permission denied"]
-            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
-            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-7" in compose_id:
+            pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
+        if "RHEL-7" in compose_id and pkg[16:21] < '2.20':
+            msg = "'password': is not in latin1 encoding"
+            res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=0, exp_send=0)
+            res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
             results.setdefault('step3', []).append(res1)
             results.setdefault('step3', []).append(res2)
+        else:
+            if "libvirt-remote" in hypervisor_type:
+                logger.warning("libvirt-remote can use sshkey to connect, password value is not necessary")
+                res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+                results.setdefault('step3', []).append(res1)
+            else:
+                res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=0)
+                res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+                results.setdefault('step3', []).append(res1)
+                results.setdefault('step3', []).append(res2)
 
         logger.info(">>>step4: password option is null value")
         self.vw_option_update_value(option_tested, '', config_file)
@@ -64,7 +79,6 @@ class Testcase(Testing):
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step4', []).append(res1)
         else:
-            msg_list = ["Unable to login|incorrect user.*|Authentication failure|Incorrect.*username|Unauthorized|Error.* backend|Permission denied"]
             res1 = self.op_normal_value(data, exp_error="0|1|2", exp_thread=1, exp_send=0)
             res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
             results.setdefault('step4', []).append(res1)
@@ -78,9 +92,9 @@ class Testcase(Testing):
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step5', []).append(res1)
         else:
-            msg_list = ["PASSWORD.* not set|virt-who can't be started"]
+            msg_list_s5 = ["PASSWORD.* not set|virt-who can't be started"]
             res1 = self.op_normal_value(data, exp_error="0|1|2", exp_thread=0, exp_send=0)
-            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+            res2 = self.msg_validation(rhsm_output, msg_list_s5, exp_exist=True)
             results.setdefault('step5', []).append(res1)
             results.setdefault('step5', []).append(res2)
 
@@ -95,9 +109,9 @@ class Testcase(Testing):
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step6', []).append(res1)
         else:
-            msg_list = ["PASSWORD.* not set"]
+            msg_list_s6 = ["PASSWORD.* not set"]
             res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=1)
-            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+            res2 = self.msg_validation(rhsm_output, msg_list_s6, exp_exist=True)
             results.setdefault('step6', []).append(res1)
             results.setdefault('step6', []).append(res2)
 
@@ -110,14 +124,10 @@ class Testcase(Testing):
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step7', []).append(res1)
         else:
-            msg_list = ["Unable to login|incorrect user.*|Authentication failure|Incorrect.*username|Unauthorized|Error.* backend|Permission denied"]
             res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=1, exp_send=1)
             res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
             results.setdefault('step7', []).append(res1)
             results.setdefault('step7', []).append(res2)
 
         # Case Result
-        notes = list()
-        notes.append("Bug(Step3): 'ascii' codec can't decode")
-        notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1703317")
-        self.vw_case_result(results, notes)
+        self.vw_case_result(results)


### PR DESCRIPTION
Add checking python-requests version for RHEL7,  when run virt-who and set password with unicode characters with python-requests < '2.20', virt-who will be failed to start with error "option 'password': is not in latin1 encoding. That is not allowed on this system."

```
# pytest-2 tests/tier2/tc_2004_validate_username_option_by_cli.py tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py 
============================ test session starts ===========================                                                                                                                         tests/tier2/tc_2004_validate_username_option_by_cli.py .                                                                                   [ 50%]
tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py .                                                                         [100%]

====================== 2 passed in 624.43 seconds===========================
```