### PR TITLE
Update cli options for kubevirt

### DIFF
--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -718,9 +718,9 @@ class Testing(Provision):
         elif mode == "vdsm":
             cmd = "virt-who --vdsm "
         elif mode == "kubevirt":
-            server_config = hypervisor_config['server_config']
-            ret, output = self.runcmd("export KUBECONFIG={0}".format(server_config), self.ssh_host())
-            cmd = "virt-who {0} {1} {2} ".format(cf_type, cf_owner, cf_env)
+            kube_cfg = deploy.kubevirt.kube_config_file
+            cf_kube_cfg = "--{0}-cfg={1}".format(mode, kube_cfg)
+            cmd = "virt-who {0} {1} {2} {3} ".format(cf_type, cf_owner, cf_env, cf_kube_cfg)
         else:
             cmd = "virt-who {0} {1} {2} {3} {4} {5} ".format(
                     cf_type, cf_owner, cf_env, cf_server, cf_username, cf_password)


### PR DESCRIPTION
Update cli options for kubevirt due to Bug 1751441 fixed. 
The valid cli options are "# virt-who --kubevirt --kubevirt-owner=xxx --kubevirt-cfg=kubeconfig_path"
```
# pytest-2 tests/tier1/tc_1009_check_virtwho_fetch_and_send_function_by_cli.py tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py tests/tier1/tc_1014_check_interval_function_by_cli.py tests/tier1/tc_1016_check_print_function_by_cli.py tests/tier1/tc_1018_check_log_per_config_function_by_cli.py tests/tier1/tc_1019_check_log_dir_function_by_cli.py tests/tier1/tc_1020_check_log_file_function_by_cli.py tests/tier1/tc_1021_check_reporter_id_function_by_cli.py tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py tests/tier2/tc_2001_validate_owner_option_by_cli.py tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py 
================== test session starts ==================
collected 12 items                                                                                         

tests/tier1/tc_1009_check_virtwho_fetch_and_send_function_by_cli.py .                                [  8%]
tests/tier1/tc_1010_check_virtwho_debug_function_by_cli.py .                                         [ 16%]
tests/tier1/tc_1012_check_virtwho_oneshot_function_by_cli.py .                                       [ 25%]
tests/tier1/tc_1014_check_interval_function_by_cli.py .                                              [ 33%]
tests/tier1/tc_1016_check_print_function_by_cli.py .                                                 [ 41%]
tests/tier1/tc_1018_check_log_per_config_function_by_cli.py .                                        [ 50%]
tests/tier1/tc_1019_check_log_dir_function_by_cli.py .                                               [ 58%]
tests/tier1/tc_1020_check_log_file_function_by_cli.py .                                              [ 66%]
tests/tier1/tc_1021_check_reporter_id_function_by_cli.py .                                           [ 75%]
tests/tier1/tc_1037_check_sam_satellite_options_by_cli.py .                                          [ 83%]
tests/tier2/tc_2001_validate_owner_option_by_cli.py .                                                [ 91%]
tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py .                                      [100%]

================== 12 passed in 1825.21 seconds ==================
```