### PR TITLE
Update tc_2038 due to different behaviors for rhel7 and rhel8

### DIFF
--- a/tests/tier2/tc_2038_validate_global_configs_by_virtwho_conf.py
+++ b/tests/tier2/tc_2038_validate_global_configs_by_virtwho_conf.py
@@ -54,13 +54,26 @@ class Testcase(Testing):
         self.vw_option_update_value('configs', 'xxxxxx', virtwho_conf)
         error_msg_1 = 'Unable to read configuration file'
         error_msg_2 = 'No valid configuration file provided using -c/--config'
-        data, tty_output, rhsm_output = self.vw_start(exp_send=0, exp_error=True)
-        res1 = self.op_normal_value(data, exp_error=2, exp_thread=0, exp_send=0)
-        res2 = self.vw_msg_search(rhsm_output, error_msg_1, exp_exist=True)
-        res3 = self.vw_msg_search(rhsm_output, error_msg_2, exp_exist=True)
-        results.setdefault('step3', []).append(res1)
-        results.setdefault('step3', []).append(res2)
-        results.setdefault('step3', []).append(res3)
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-7" in compose_id:
+            data, tty_output, rhsm_output = self.vw_start(exp_send=1, exp_error=True)
+            res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=1)
+            res2 = self.vw_msg_search(str(data), error_msg_1, exp_exist=True)
+            results.setdefault('step3', []).append(res1)
+            results.setdefault('step3', []).append(res2)
+            # check virt-who has run config_file_2
+            num = rhsm_output.count('"guestId": "{0}"'.format(guest_uuid))
+            logger.info("Actual mapping info num: {0}".format(num))
+            logger.info("Expected mapping info num: 1 for sat63 above and stage")
+            results.setdefault('step3', []).append(num == 1)
+        else:
+            data, tty_output, rhsm_output = self.vw_start(exp_send=0, exp_error=True)
+            res1 = self.op_normal_value(data, exp_error=2, exp_thread=0, exp_send=0)
+            res2 = self.vw_msg_search(rhsm_output, error_msg_1, exp_exist=True)
+            res3 = self.vw_msg_search(rhsm_output, error_msg_2, exp_exist=True)
+            results.setdefault('step3', []).append(res1)
+            results.setdefault('step3', []).append(res2)
+            results.setdefault('step3', []).append(res3)
 
         # Case Result
         self.vw_case_result(results)


### PR DESCRIPTION
When run virt-who with "configs=bad file" under /etc/virt-who.conf, the behaviors are different.
RHEL-7: Virt-who is failed to run the bad file and succeeded to report all available hypervisors in /etc/virt-who.d/
RHEL-8: Virt-who is failed to be started as https://bugzilla.redhat.com/show_bug.cgi?id=1804072 was closed as NOTABUG.

```
# pytest-2 tests/tier2/tc_2038_validate_global_configs_by_virtwho_conf.py 
================= test session starts =================
collected 1 item                                                                                           

tests/tier2/tc_2038_validate_global_configs_by_virtwho_conf.py .                                     [100%]

================= 1 passed in 186.96 seconds =================
```