### PR TITLE
Update tc_2026 based on bz1780467

### DIFF
--- a/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
@@ -51,18 +51,16 @@ class Testcase(Testing):
 
         logger.info(">>>step3: run virt-who with rhsm_password=红帽©¥®ðπ∉")
         '''红帽©¥®ðπ∉ password is supported by candlepin'''
-        msg_list = ["codec can't decode|"
-                    "Communication with subscription manager failed"]
         self.vw_option_update_value("rhsm_password", "红帽©¥®ðπ∉", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         compose_id = self.get_config('rhel_compose')
         if "RHEL-7" in compose_id:
-            pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
-        if "RHEL-7" in compose_id and pkg[16:21] < '2.20':
             msg = "not in latin1 encoding"
             res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=0, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
         else:
+            msg_list = ["codec can't decode|"
+                        "Communication with subscription manager failed"]
             res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
             res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step3', []).append(res1)

--- a/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
@@ -55,8 +55,16 @@ class Testcase(Testing):
                     "Communication with subscription manager failed"]
         self.vw_option_update_value("rhsm_password", "红帽©¥®ðπ∉", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
-        res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-7" in compose_id:
+            pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
+        if "RHEL-7" in compose_id and pkg[16:21] < '2.20':
+            msg = "not in latin1 encoding"
+            res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=0, exp_send=0)
+            res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)
+        else:
+            res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=1, exp_send=0)
+            res2 = self.msg_validation(rhsm_output, msg_list, exp_exist=True)
         results.setdefault('step3', []).append(res1)
         results.setdefault('step3', []).append(res2)
 


### PR DESCRIPTION
Update tc_2026 based on https://bugzilla.redhat.com/show_bug.cgi?id=1780467, the behaviors are different for rhel7 and rhel8 because of python-request version difference.

```
# pytest-2 tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py 
=========================== test session starts ============================
tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py .<font color="#06989A">                                                                    [100%]</font>
===================== 1 passed in 260.20 seconds ========================
```