### PR TITLE
update tc_2029 due to not support  rhel7

### DIFF
--- a/tests/tier2/tc_2029_validate_wildcard_for_filter_and_exclude_host_parents_options_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2029_validate_wildcard_for_filter_and_exclude_host_parents_options_in_etc_virtwho_d.py
@@ -10,6 +10,10 @@ class Testcase(Testing):
         hypervisor_type = self.get_config('hypervisor_type')
         if hypervisor_type not in ('esx'):
             self.vw_case_skip(hypervisor_type)
+        # Bug 1461272 only be fixed in rhel8, so rhel7 doesn't support this function
+        compose_id = self.get_config('rhel_compose')
+        if "RHEL-7" in compose_id:
+            self.vw_case_skip(compose_id)
         self.vw_case_init()
 
         # Case Config


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1461272 was moved to rhel-8 fix and by confirming with devel team, they will not fix any RFE bug for rhel-7, so skip this case from rhel7 library.