### PR TITLE
Add automation coverage for bz1779812

### DIFF
--- a/tests/tier2/tc_2063_check_hypervisors_fqdn.py
+++ b/tests/tier2/tc_2063_check_hypervisors_fqdn.py
@@ -1,0 +1,61 @@
+# coding:utf-8
+from virt_who import *
+from virt_who.base import Base
+from virt_who.register import Register
+from virt_who.testing import Testing
+
+
+class Testcase(Testing):
+    def test_run(self):
+        self.vw_case_info(os.path.basename(__file__), case_id='RHEL-188359')
+        self.vw_case_init()
+
+        # Case Config
+        results = dict()
+        register_config = self.get_register_config()
+        server = register_config['server']
+        ssh_user = register_config['ssh_user']
+        ssh_passwd = register_config['ssh_passwd']
+        ssh_register = {"host": server, "username": ssh_user, "password": ssh_passwd}
+        admin_user = register_config['username']
+        admin_passwd = register_config['password']
+        config_name = "virtwho-config"
+        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+        self.vw_etc_d_mode_create(config_name, config_file)
+        self.vw_option_add("hypervisor_id", "hostname", config_file)
+        json_file = "/tmp/fake.json"
+        conf_file = "/etc/virt-who.d/fake.conf"
+        host_name = self.get_hypervisor_hostname()
+
+        # Case Steps
+        logger.info(">>>step1: create fake json file")
+        cli = "virt-who"
+        self.vw_fake_json_create(cli, json_file)
+        self.vw_etc_d_delete_all()
+        self.vw_fake_conf_create(conf_file, json_file, True)
+
+        logger.info(">>>step2: run virt-who with fake conf")
+        data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+        res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+        results.setdefault('step1', []).append(res1)
+
+        logger.info(">>>step3: use hammer command to check hypervisor's fqdn")
+        cmd = "hammer -u {0} -p {1} host list --search 'name ~ virt-who*'".format(admin_user, admin_passwd)
+        _, result = self.runcmd(cmd, ssh_register)
+        self.vw_msg_search(result, "virt-who-"+host_name)
+
+        logger.info(">>>step4: run virt-who with the new hypervisor's fqdn")
+        new_name = "newserver.rhts.eng.pek2.redhat.com"
+        self.vw_fake_json_update(host_name, new_name, json_file)
+        data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+        res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+        results.setdefault('step1', []).append(res1)
+
+        logger.info(">>>step5: use hammer command to check the new hypervisor's fqdn")
+        cmd = "hammer -u {0} -p {1} host list --search 'name ~ virt-who*'".format(admin_user, admin_passwd)
+        _, result = self.runcmd(cmd, ssh_register)
+        self.vw_msg_search(result, "virt-who-"+new_name)
+        self.vw_msg_search(result, "virt-who-"+host_name, False)
+
+        # Case Result
+        self.vw_case_result(results)

--- a/tests/tier2/tc_2063_check_hypervisors_fqdn.py
+++ b/tests/tier2/tc_2063_check_hypervisors_fqdn.py
@@ -8,6 +8,9 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-188359')
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type in ('libvirt-local', 'vdsm'):
+            self.vw_case_skip(hypervisor_type)
         self.vw_case_init()
 
         # Case Config

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -625,6 +625,16 @@ class Testing(Provision):
             raise FailException("Failed to create fake config file: {0}".format(conf_file))
         logger.info("Succeeded to create fake config file: {0}".format(conf_file))
 
+    def vw_fake_json_update(self, name, rename, filename):
+        option = self.shell_escape_char(name)
+        rename = self.shell_escape_char(rename)
+        cmd = 'sed -i "s|%s|%s|g" %s' % (option, rename, filename)
+        ret, output = self.runcmd(cmd, self.ssh_host())
+        if ret == 0:
+            logger.info("Succeeded to update json value %s to %s" % (option, rename))
+        else:
+            raise FailException("Failed to update json value %s to %s" % (option, rename))
+
     def vw_option_update_name(self, option, rename, filename):
         option = self.shell_escape_char(option)
         rename = self.shell_escape_char(rename)


### PR DESCRIPTION
**Description**
Add automation coverage for [BZ1779812](https://bugzilla.redhat.com/show_bug.cgi?id=1779812)
Test case from polarion: https://polarion.engineering.redhat.com/polarion/#/project/RedHatEnterpriseLinux7/workitem?id=RHEL-188359

**Test Result**
```
[hkx303@kuhuang tier2]$ nosetests tc_2063_check_hypervisors_fqdn.py 
2020-06-18 19:19:40 [INFO] ++++++++++++++++++++++++++++++
2020-06-18 19:19:40 [INFO] RHEL-188359:tc_2063_check_hypervisors_fqdn.py
2020-06-18 19:20:28 [INFO] Succeeded to get esxi host uuid: 9bff4d56-3b59-6355-ece2-e02094d27d11
2020-06-18 19:20:29 [INFO] Host(bootp-73-131-226.rhts.eng.pek2.redhat.com) is not found in satellite server
2020-06-18 19:20:35 [INFO] Succeeded to unregister and clean system(ent-02-vm-03.lab.eng.nay.redhat.com)
2020-06-18 19:21:04 [INFO] Succeeded to register system ent-02-vm-03.lab.eng.nay.redhat.com to ent-02-vm-06.lab.eng.nay.redhat.com(satellite66-cdn-rhel7)
2020-06-18 19:21:08 [INFO] Succeeded to unregister and clean system(10.73.131.205)
2020-06-18 19:21:26 [INFO] Succeeded to register system 10.73.131.205 to ent-02-vm-06.lab.eng.nay.redhat.com(satellite66-cdn-rhel7)
2020-06-18 19:21:26 [INFO] Succeeded to disable all options in /etc/virt-who.conf
2020-06-18 19:21:27 [INFO] Succeeded to disable all options in /etc/sysconfig/virt-who
2020-06-18 19:21:28 [INFO] Succeeded to delete all files in /etc/virt-who.d/
2020-06-18 19:21:31 [INFO] Succeeded to create config file /etc/virt-who.d/virtwho-config.conf
2020-06-18 19:21:32 [INFO] Succeeded to add option hypervisor_id=hostname
2020-06-18 19:21:49 [INFO] >>>step1: create fake json file
2020-06-18 19:22:05 [INFO] {"hypervisors": [{"uuid": "bootp-73-131-226.rhts.eng.pek2.redhat.com", "guests": [{"guestId": "42216992-7a40-5701-a681-3e560a389cdd", "state": 1, "attributes": {"active": 1, "virtWhoType": "esx"}}], "facts": {"hypervisor.type": "VMware ESXi", "dmi.system.uuid": "9bff4d56-3b59-6355-ece2-e02094d27d11", "cpu.cpu_socket(s)": "1", "hypervisor.cluster": "virtwho-test", "hypervisor.version": "6.7.0"}, "name": "bootp-73-131-226.rhts.eng.pek2.redhat.com"}]}
2020-06-18 19:22:05 [INFO] Succeeded to create json data: /tmp/fake.json
2020-06-18 19:22:06 [INFO] Succeeded to delete all files in /etc/virt-who.d/
2020-06-18 19:22:10 [INFO] Succeeded to create fake config file: /etc/virt-who.d/fake.conf
2020-06-18 19:22:10 [INFO] >>>step2: run virt-who with fake conf
2020-06-18 19:22:25 [INFO] Start to run virt-who by service
2020-06-18 19:22:43 [INFO] pending_job: 0, is_429: no, loop_num: 0, loop_time: -1, send_num: 1, error_num: 0, thread_num: 1
2020-06-18 19:22:43 [INFO] virt-who is terminated by expected_send and expected_loop ready
2020-06-18 19:23:00 [INFO] virtwho thread number(1) is expected
2020-06-18 19:23:00 [INFO] virtwho error number(0) is expected
2020-06-18 19:23:00 [INFO] virtwho send number(1) is expected
2020-06-18 19:23:00 [INFO] Finished to validate all the expected options
2020-06-18 19:23:00 [INFO] >>>step3: use hammer command to check hypervisor's fqdn
2020-06-18 19:23:05 [INFO] Succeeded to search, expected msg(virt-who-bootp-73-131-226.rhts.eng.pek2.redhat.com) is exist(1)
2020-06-18 19:23:05 [INFO] >>>step4: run virt-who with the new hypervisor's fqdn
2020-06-18 19:23:06 [INFO] Succeeded to update json value bootp-73-131-226.rhts.eng.pek2.redhat.com to newserver.rhts.eng.pek2.redhat.com
2020-06-18 19:23:21 [INFO] Start to run virt-who by service
2020-06-18 19:23:39 [INFO] pending_job: 0, is_429: no, loop_num: 0, loop_time: -1, send_num: 1, error_num: 0, thread_num: 1
2020-06-18 19:23:39 [INFO] virt-who is terminated by expected_send and expected_loop ready
2020-06-18 19:23:55 [INFO] virtwho thread number(1) is expected
2020-06-18 19:23:55 [INFO] virtwho error number(0) is expected
2020-06-18 19:23:55 [INFO] virtwho send number(1) is expected
2020-06-18 19:23:55 [INFO] Finished to validate all the expected options
2020-06-18 19:23:55 [INFO] >>>step5: use hammer command to check the new hypervisor's fqdn
2020-06-18 19:23:59 [INFO] Succeeded to search, expected msg(virt-who-newserver.rhts.eng.pek2.redhat.com) is exist(1)
2020-06-18 19:23:59 [INFO] Succeeded to search, unexpected msg(virt-who-bootp-73-131-226.rhts.eng.pek2.redhat.com) is not exist(0)
2020-06-18 19:23:59 [INFO] Succeeded to run case, all steps passed

.
----------------------------------------------------------------------
Ran 1 test in 258.580s

OK
```

**Additional info**
First time to add a new case to the virt-who ci framework, any thoughts/suggestions are appreciated. Thanks:)