### PR TITLE
Get vcenter guest uuid based on VMware version

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2057,6 +2057,8 @@ class Provision(Register):
         cmd = "%s Get-VM %s | %%{(Get-View $_.Id).config}" % (cert, guest_name)
         ret, output = self.runcmd(cmd, ssh_vcenter)
         if ret == 0:
+            version = ''
+            uuid = ''
             for line in output.splitlines():
                 if re.match(r"^Version.*:", line):
                     version = line.split(':')[1].strip()

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2061,15 +2061,14 @@ class Provision(Register):
                 if re.match(r"^Version.*:", line):
                     version = line.split(':')[1].strip()
                     logger.info("Succeeded to get the VMware version: {0}".format(version))
-            for line in output.splitlines():
                 if re.match(r"^Uuid.*:", line):
                     s = line.split(':')[1].strip()
-                    if version > "vmx-13":
-                        uuid = s[6:8] + s[4:6] + s[2:4] + s[0:2] + "-" + s[11:13] + s[9:11] + "-" + s[16:18] + s[14:16] + "-" + s[19:]
-                    else:
-                        uuid = s
-                    logger.info("Succeeded to get vcenter guest uuid: {0}".format(uuid))
-                    return uuid
+            if version > "vmx-13":
+                uuid = s[6:8] + s[4:6] + s[2:4] + s[0:2] + "-" + s[11:13] + s[9:11] + "-" + s[16:18] + s[14:16] + "-" + s[19:]
+            else:
+                uuid = s
+            logger.info("Succeeded to get vcenter guest uuid: {0}".format(uuid))
+            return uuid
         else:
             raise FailException("Failed to get vcenter guest uuid")
 

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2058,8 +2058,16 @@ class Provision(Register):
         ret, output = self.runcmd(cmd, ssh_vcenter)
         if ret == 0:
             for line in output.splitlines():
+                if re.match(r"^Version.*:", line):
+                    version = line.split(':')[1].strip()
+                    logger.info("Succeeded to get the VMware version: {0}".format(version))
+            for line in output.splitlines():
                 if re.match(r"^Uuid.*:", line):
-                    uuid = line.split(':')[1].strip()
+                    s = line.split(':')[1].strip()
+                    if version > "vmx-13":
+                        uuid = s[6:8] + s[4:6] + s[2:4] + s[0:2] + "-" + s[11:13] + s[9:11] + "-" + s[16:18] + s[14:16] + "-" + s[19:]
+                    else:
+                        uuid = s
                     logger.info("Succeeded to get vcenter guest uuid: {0}".format(uuid))
                     return uuid
         else:

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2064,7 +2064,7 @@ class Provision(Register):
                     version = line.split(':')[1].strip()
                 if re.match(r"^Uuid.*:", line):
                     uuid = line.split(':')[1].strip()
-            if uuid and version:
+            if uuid:
                 if version > "vmx-13":
                     uuid = uuid[6:8] + uuid[4:6] + uuid[2:4] + uuid[0:2] + "-" + uuid[11:13] + uuid[9:11] + "-" + uuid[16:18] + uuid[14:16] + "-" + uuid[19:]
                 logger.info("Succeeded to get vcenter guest uuid: {0}".format(uuid))

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2062,15 +2062,15 @@ class Provision(Register):
             for line in output.splitlines():
                 if re.match(r"^Version.*:", line):
                     version = line.split(':')[1].strip()
-                    logger.info("Succeeded to get the VMware version: {0}".format(version))
                 if re.match(r"^Uuid.*:", line):
-                    s = line.split(':')[1].strip()
-            if version > "vmx-13":
-                uuid = s[6:8] + s[4:6] + s[2:4] + s[0:2] + "-" + s[11:13] + s[9:11] + "-" + s[16:18] + s[14:16] + "-" + s[19:]
+                    uuid = line.split(':')[1].strip()
+            if uuid and version:
+                if version > "vmx-13":
+                    uuid = uuid[6:8] + uuid[4:6] + uuid[2:4] + uuid[0:2] + "-" + uuid[11:13] + uuid[9:11] + "-" + uuid[16:18] + uuid[14:16] + "-" + uuid[19:]
+                logger.info("Succeeded to get vcenter guest uuid: {0}".format(uuid))
+                return uuid
             else:
-                uuid = s
-            logger.info("Succeeded to get vcenter guest uuid: {0}".format(uuid))
-            return uuid
+                raise FailException("Failed to get vcenter guest uuid")
         else:
             raise FailException("Failed to get vcenter guest uuid")
 


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=1809098, updated code to get vcenter guest uuid based on VMware version.

```
pytest tests/tier1/tc_1008_check_virtwho_fetch_and_send_function_by_virtwho_d.py tests/tier1/tc_1062_check_global_log_file_option_in_etc_virtwho_conf.py 
============================ test session starts ============================
tests/tier1/tc_1008_check_virtwho_fetch_and_send_function_by_virtwho_d.py .                                                                [ 50%]
tests/tier1/tc_1062_check_global_log_file_option_in_etc_virtwho_conf.py .                                                                  [100%]

============================== 2 passed in 310.93 seconds ==================
```