### PR TITLE
Workaround method to fix 429 code issue

### DIFF
--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -1132,10 +1132,9 @@ class Testing(Provision):
                 register_config = self.get_register_config()
                 register_type = register_config['type']
                 self.runcmd("\cp -f /etc/rhsm/rhsm.conf /root/rhsm429.conf", self.ssh_host())
-                self.system_unregister(self.ssh_host())
                 self.system_register_config(self.ssh_host(), register_type, register_config)
                 self.system_register(self.ssh_host(), register_type, register_config)
-                self.runcmd("mv /root/rhsm429.conf /etc/rhsm/rhsm.conf", self.ssh_host())
+                self.runcmd("mv -f /root/rhsm429.conf /etc/rhsm/rhsm.conf", self.ssh_host())
                 time.sleep(wait_time)
             elif len(data['pending_job']) > 0:
                 wait_time = 60*(i+1)

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -1124,13 +1124,11 @@ class Testing(Provision):
         return data, tty_output, rhsm_output
 
     def vw_start(self, cli=None, timeout=900, exp_send=1, exp_loopnum=0, oneshot=False, event=None, web_check=True, exp_error=False):
-        for i in range(3):
+        for i in range(4):
             data, tty_output, rhsm_output = self.vw_start_thread(cli, timeout, exp_send, exp_loopnum, oneshot, event, exp_error)
             if data['is_429'] == "yes":
                 wait_time = 60*(i+3)
-                logger.warning("429 code found, try again after %s seconds..." % wait_time)
-                time.sleep(wait_time)
-                logger.warning("429 code found, re-register virt-who host and try again")
+                logger.warning("429 code found, re-register virt-who host and try again after %s seconds..." % wait_time)
                 register_config = self.get_register_config()
                 register_type = register_config['type']
                 self.runcmd("\cp -f /etc/rhsm/rhsm.conf /root/rhsm429.conf", self.ssh_host())
@@ -1138,6 +1136,7 @@ class Testing(Provision):
                 self.system_register_config(self.ssh_host(), register_type, register_config)
                 self.system_register(self.ssh_host(), register_type, register_config)
                 self.runcmd("mv /root/rhsm429.conf /etc/rhsm/rhsm.conf", self.ssh_host())
+                time.sleep(wait_time)
             elif len(data['pending_job']) > 0:
                 wait_time = 60*(i+1)
                 logger.warning("Job is not finished, cancel it and try again after %s seconds..." % wait_time)

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -1130,6 +1130,14 @@ class Testing(Provision):
                 wait_time = 60*(i+3)
                 logger.warning("429 code found, try again after %s seconds..." % wait_time)
                 time.sleep(wait_time)
+                logger.warning("429 code found, re-register virt-who host and try again")
+                register_config = self.get_register_config()
+                register_type = register_config['type']
+                self.runcmd("\cp -f /etc/rhsm/rhsm.conf /root/rhsm429.conf", self.ssh_host())
+                self.system_unregister(self.ssh_host())
+                self.system_register_config(self.ssh_host(), register_type, register_config)
+                self.system_register(self.ssh_host(), register_type, register_config)
+                self.runcmd("mv /root/rhsm429.conf /etc/rhsm/rhsm.conf", self.ssh_host())
             elif len(data['pending_job']) > 0:
                 wait_time = 60*(i+1)
                 logger.warning("Job is not finished, cancel it and try again after %s seconds..." % wait_time)


### PR DESCRIPTION
When 429 code issue appears for stage candlepin, will re-register virt-who host firstly and then wait some time to try again.
Because some cases need to change /etc/rhsm/rhsm.conf, like case for testing rhsm proxy in the file, so we need backup the file before re-register and then recover it.
```
# pytest-2 tests/tier1/tc_1039_check_http_proxy_option_by_etc_sysconfig.py tests/tier1/tc_1045_check_rhsm_proxy_function_in_rhsm_conf.py 
==================== test session starts ==================
tests/tier1/tc_1039_check_http_proxy_option_by_etc_sysconfig.py .                                                                          [ 50%]
tests/tier1/tc_1045_check_rhsm_proxy_function_in_rhsm_conf.py .                                                                            [100%]

===================== 2 passed in 1847.38 seconds =================
```