### PR TITLE
Update tc_1048/1049/2029 based on bz1461272 fixed

### DIFF
--- a/tests/tier1/tc_1048_check_filter_host_parents_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1048_check_filter_host_parents_option_in_etc_virtwho_d.py
@@ -24,8 +24,8 @@ class Testcase(Testing):
         host_hwuuid = self.get_hypervisor_hwuuid()
 
         # case steps
-        logger.info(">>>step1: run virt-who with filter_host_parents=*")
-        self.vw_option_add("filter_host_parents", "*", filename=config_file)
+        logger.info(">>>step1: run virt-who with filter_host_parents='' to get domain_id")
+        self.vw_option_add("filter_host_parents", "", filename=config_file)
         data, tty_output, rhsm_output = self.vw_start()
         s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step1', []).append(s1)
@@ -42,12 +42,12 @@ class Testcase(Testing):
         s2 = self.vw_msg_search(str(data), host_uuid, exp_exist=True)
         results.setdefault('step2', []).append(s2)
 
-        logger.info(">>>step3: run virt-who with filter_host_parents=")
-        self.vw_option_update_value("filter_host_parents", "", filename=config_file)
+        logger.info(">>>step3: run virt-who with filter_host_parents=*")
+        self.vw_option_update_value("filter_host_parents", "*", filename=config_file)
         data, tty_output, rhsm_output = self.vw_start()
         s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step3', []).append(s1)
-        s2 = self.vw_msg_search(str(data), host_uuid, exp_exist=False)
+        s2 = self.vw_msg_search(str(data), host_uuid, exp_exist=True)
         results.setdefault('step3', []).append(s2)
 
         # case result

--- a/tests/tier1/tc_1049_check_exclude_host_parents_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1049_check_exclude_host_parents_option_in_etc_virtwho_d.py
@@ -24,8 +24,8 @@ class Testcase(Testing):
         host_hwuuid = self.get_hypervisor_hwuuid()
 
         # case steps
-        logger.info(">>>step1: run virt-who with filter_host_parents=*")
-        self.vw_option_add("filter_host_parents", "*", filename=config_file)
+        logger.info(">>>step1: run virt-who with exlude_host_parents=* to get domain_id")
+        self.vw_option_add("exclude_host_parents", "*", filename=config_file)
         data, tty_output, rhsm_output = self.vw_start()
         s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step1', []).append(s1)
@@ -43,15 +43,7 @@ class Testcase(Testing):
         s2 = self.vw_msg_search(str(data), host_uuid, exp_exist=False)
         results.setdefault('step2', []).append(s2)
 
-        logger.info(">>>step3: run virt-who with exclude_host_parents=*")
-        self.vw_option_update_value("exclude_host_parents", "*", filename=config_file)
-        data, tty_output, rhsm_output = self.vw_start()
-        s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-        results.setdefault('step3', []).append(s1)
-        s2 = self.vw_msg_search(str(data), host_uuid, exp_exist=True)
-        results.setdefault('step3', []).append(s2)
-
-        logger.info(">>>step4: run virt-who with exclude_host_parents=")
+        logger.info(">>>step3: run virt-who with exclude_host_parents=")
         self.vw_option_update_value("exclude_host_parents", "", filename=config_file)
         data, tty_output, rhsm_output = self.vw_start()
         s1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)

--- a/tests/tier2/tc_2029_validate_wildcard_for_filter_and_exclude_host_parents_options_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2029_validate_wildcard_for_filter_and_exclude_host_parents_options_in_etc_virtwho_d.py
@@ -31,8 +31,8 @@ class Testcase(Testing):
         host_name = self.get_hypervisor_hostname()
 
         # Case Steps
-        logger.info(">>>step1: run virt-who with filter_host_parents=* to check the domain_id")
-        self.vw_option_add("filter_host_parents", "*", config_file)
+        logger.info(">>>step1: run virt-who with filter_host_parents= to check the domain_id")
+        self.vw_option_add("filter_host_parents", "", config_file)
         data, tty_output, rhsm_output = self.vw_start()
         res = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step1', []).append(res)
@@ -62,7 +62,7 @@ class Testcase(Testing):
                     self.vw_option_add("filter_host_parents", value, config_file)
                 data, tty_output, rhsm_output = self.vw_start()
                 res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
-                if key == "step2":
+                if key == "step4":
                     res2 = self.vw_msg_search(str(data), hypervisorId, exp_exist=False)
                 else:
                     res2 = self.vw_msg_search(str(data), hypervisorId, exp_exist=True)
@@ -77,7 +77,4 @@ class Testcase(Testing):
             self.stage_consumer_clean(self.ssh_host(), register_config)
 
         # Case Result
-        notes = list()
-        notes.append("Bug: wildcard(*) is not valid for filter_host_parents and exclude_host_parents")
-        notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1461272")
-        self.vw_case_result(results, notes)
+        self.vw_case_result(results)


### PR DESCRIPTION
Update the three cases based on Bug 1461272 fixed, now "filter/exclude_host_parents=" options support using wildcard "*" , so we need to run virt-who with filter_host_parents=' ' or exclude_host_parents=* to get domain_id.

```
# pytest-3.7 tests/tier1/tc_1048_check_filter_host_parents_option_in_etc_virtwho_d.py tests/tier1/tc_1049_check_exclude_host_parents_option_in_etc_virtwho_d.py tests/tier2/tc_2029_validate_wildcard_for_filter_and_exclude_host_parents_options_in_etc_virtwho_d.py

================================== test session starts ==============================
platform linux -- Python 3.7.0, pytest-3.6.4, py-1.5.4, pluggy-0.6.0
collected 3 items                                                                                                                                

tests/tier1/tc_1048_check_filter_host_parents_option_in_etc_virtwho_d.py ✓✓✓                                    [ 33%]
tests/tier1/tc_1049_check_exclude_host_parents_option_in_etc_virtwho_d.py ✓✓✓                                   [ 66%]
tests/tier2/tc_2029_validate_wildcard_for_filter_and_exclude_host_parents_options_in_etc_virtwho_d.py ✓✓✓       [100%]

======================== 9 passed, 23 warnings in 1206.08 seconds ====================
```