### PR TITLE
update test cases based on new bz1855550

### DIFF
--- a/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
@@ -51,8 +51,7 @@ class Testcase(Testing):
                 logger.error("Failed to search hypervisorId:{0}".format(hypervisorId))
                 results.setdefault(step, []).append(False)
             self.vw_option_del("hypervisor_id", filename=config_file)
-            if "satellite" in register_type:
-                self.vw_web_host_delete(host_name, hypervisorId)
+            self.vw_web_host_delete(host_name, hypervisorId)
         if "stage" in register_type:
             self.stage_consumer_clean(self.ssh_host(), register_config)
 

--- a/tests/tier1/tc_1053_check_hypervisor_id_and_filter_hosts_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1053_check_hypervisor_id_and_filter_hosts_option_in_etc_virtwho_d.py
@@ -54,8 +54,7 @@ class Testcase(Testing):
                 results.setdefault(step, []).append(False)
             self.vw_option_del("hypervisor_id", filename=config_file)
             self.vw_option_del("filter_hosts", filename=config_file)
-            if "satellite" in register_type:
-                self.vw_web_host_delete(host_name, hypervisorId)
+            self.vw_web_host_delete(host_name, hypervisorId)
         if "stage" in register_type:
             self.stage_consumer_clean(self.ssh_host(), register_config)
 

--- a/tests/tier1/tc_1054_check_hypervisor_id_and_exclude_hosts_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1054_check_hypervisor_id_and_exclude_hosts_option_in_etc_virtwho_d.py
@@ -49,8 +49,7 @@ class Testcase(Testing):
             results.setdefault(step, []).append(s2)
             self.vw_option_del("hypervisor_id", filename=config_file)
             self.vw_option_del("exclude_hosts", filename=config_file)
-            if "satellite" in register_type:
-                self.vw_web_host_delete(host_name, hypervisorId)
+            self.vw_web_host_delete(host_name, hypervisorId)
         if "stage" in register_type:
             self.stage_consumer_clean(self.ssh_host(), register_config)
 

--- a/tests/tier1/tc_1067_check_defaults_hypervisor_id_option_in_etc_virtwho_conf.py
+++ b/tests/tier1/tc_1067_check_defaults_hypervisor_id_option_in_etc_virtwho_conf.py
@@ -54,8 +54,7 @@ class Testcase(Testing):
                 logger.error("Failed to search hypervisorId:{0}".format(hypervisorId))
                 results.setdefault(step, []).append(False)
             self.vw_option_del("hypervisor_id", filename=config_file)
-            if "satellite" in register_type:
-                self.vw_web_host_delete(host_name, hypervisorId)
+            self.vw_web_host_delete(host_name, hypervisorId)
         if "stage" in register_type:
             self.stage_consumer_clean(self.ssh_host(), register_config)
 

--- a/tests/tier2/tc_2028_validate_wildcard_for_filter_and_exclude_hosts_options_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2028_validate_wildcard_for_filter_and_exclude_hosts_options_in_etc_virtwho_d.py
@@ -61,8 +61,7 @@ class Testcase(Testing):
                 results.setdefault(step, []).append(res2)
                 self.vw_option_del("filter_hosts", config_file)
             self.vw_option_del("hypervisor_id", config_file)
-            if "satellite" in register_type:
-                self.vw_web_host_delete(host_name, hypervisorId)
+            self.vw_web_host_delete(host_name, hypervisorId)
         if "stage" in register_type:
             self.stage_consumer_clean(self.ssh_host(), register_config)
 

--- a/tests/tier2/tc_2029_validate_wildcard_for_filter_and_exclude_host_parents_options_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2029_validate_wildcard_for_filter_and_exclude_host_parents_options_in_etc_virtwho_d.py
@@ -71,8 +71,7 @@ class Testcase(Testing):
                 self.vw_option_del("exclude_host_parents", config_file)
                 self.vw_option_del("filter_host_parents", config_file)
             self.vw_option_del("hypervisor_id", config_file)
-            if "satellite" in register_type:
-                self.vw_web_host_delete(host_name, hypervisorId)
+            self.vw_web_host_delete(host_name, hypervisorId)
         if "stage" in register_type:
             self.stage_consumer_clean(self.ssh_host(), register_config)
 


### PR DESCRIPTION
Based on https://bugzilla.redhat.com/show_bug.cgi?id=1855550, the hypervisor id for remote libvirt in Stage Candlepin cannot updated, so we cannot get consumer uuid after run with different hypervisor_id, so we change code to delete host/hypervisor for both satellite and stage candlepin.

Add will add another case to check the webui only keeping single hypervisor item after run with hypervisor_id=uuid/hostname/hwuuid one by one.