### PR TITLE
update libvirt_guest_status()

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2681,7 +2681,8 @@ class Provision(Register):
             logger.info("libvirt({0}) guest status is: {1}".format(host, status))
             return status
         else:
-            raise FailException("Failed to check libvirt({0}) guest status".format(host))
+            logger.info("Failed to check libvirt({0}) guest status".format(host))
+            return "false"
 
     def libvirt_guests_all_clean(self, ssh_libvirt):
         host = ssh_libvirt['host']


### PR DESCRIPTION
In the original code, when failed to check libvirt guest status, it will raise fail and stop the test case directly , which makes the loop in libvirt_guest_stop() useless.

```
# pytest-3 tests/tier2/tc_2053_validate_guest_state_when_suspend_resume_stop_start.py 
/root/.local/lib/python3.7/site-packages/pep8.py:110: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
=========================== test session starts ===============================
platform linux -- Python 3.7.0, pytest-3.6.4, py-1.5.4, pluggy-0.6.0                                                                                                                            

tests/tier2/tc_2053_validate_guest_state_when_suspend_resume_stop_start.py ✓✓✓                                  [100%]

========================= 3 passed, 9 warnings in 444.61 seconds ====================
```