### PR TITLE
skip two cases for local modes in smoke testing

### DIFF
--- a/tests/smoke/test_virtwho_smoke.py
+++ b/tests/smoke/test_virtwho_smoke.py
@@ -41,6 +41,9 @@ class VirtWhoSmokeTestCase(Testing):
         assert (self.vw_web_associate(self.host_name, self.host_uuid, self.guest_name, self.guest_uuid))
 
     def test_vw_rhsm_options(self):
+        hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type in ('libvirt-local', 'vdsm'):
+            self.vw_case_skip(hypervisor_type)
         self.system_unregister(self.ssh_host())
         register_type = self.register_config['type']
         self.vw_option_add("rhsm_hostname", self.register_config['server'], self.config_file)
@@ -67,8 +70,10 @@ class VirtWhoSmokeTestCase(Testing):
             assert (self.vw_msg_search(rhsm_output, "Using proxy.*{0}".format(squid_server)))
 
     def test_vw_hypervisor_id(self):
-        register_owner = self.register_config['owner']
         hypervisor_type = self.get_config('hypervisor_type')
+        if hypervisor_type in ('libvirt-local', 'vdsm'):
+            self.vw_case_skip(hypervisor_type)
+        register_owner = self.register_config['owner']
         if hypervisor_type in ('esx', 'rhevm'):
             hypervisor_ids = ['uuid', 'hostname', 'hwuuid']
         else:


### PR DESCRIPTION
```test_vw_hypervisor_id()``` and ```test_vw_rhsm_options() ``` not for local modes.

```
# pytest-3 tests/smoke/test_virtwho_smoke.py 
======================== test session starts ========================
platform linux -- Python 3.7.0, pytest-3.6.4, py-1.5.4, pluggy-0.6.0

tests/smoke/test_virtwho_smoke.py ✓s✓✓s✓                                             [100%]

======================= 4 passed, 2 skipped, 13 warnings in 56.79 seconds ==================
```