### PR TITLE
Fix polarion import error, Add virt-who tags for test report

### DIFF
--- a/scripts/polarion_importer.py
+++ b/scripts/polarion_importer.py
@@ -118,8 +118,10 @@ def polarion_xml_init():
     attrs = {
             'polarion-project-id': 'RedHatEnterpriseLinux7',
             'polarion-testrun-id': testrun_id,
-            'polarion_custom_assignee': 'hsun',
-            'polarion_custom_isautomated': 'true'}
+            'polarion-custom-assignee': 'hsun',
+            'polarion-custom-isautomated': 'true',
+            'polarion-custom-tags': 'virt-who'}
+
     for name, value in attrs.items():
         attrs = {'name': name,'value': value}
         propertie_node = xml_createNode(properties_node, "property", attrs, '')
@@ -213,5 +215,5 @@ if __name__ == "__main__":
     xml_file, testrun_id = polarion_xml_init()
     polarion_xml_update(xml_file, files)
     polarion_caseid_mapping(xml_file)
-    # polarion_xml_import(xml_file, testrun_id)
+    polarion_xml_import(xml_file, testrun_id)
 

--- a/scripts/polarion_importer.py
+++ b/scripts/polarion_importer.py
@@ -120,7 +120,9 @@ def polarion_xml_init():
             'polarion-testrun-id': testrun_id,
             'polarion-custom-assignee': 'hsun',
             'polarion-custom-isautomated': 'true',
-            'polarion-custom-tags': 'virt-who'}
+            'polarion-custom-component': 'virt-who',
+            'polarion-custom-tags': 'virt-who',
+    }
 
     for name, value in attrs.items():
         attrs = {'name': name,'value': value}


### PR DESCRIPTION
**Description**
#96 

- [x] Fix Polarion import error

- [x] Fix the wrong parameters

- [x] Add the tags and component fields

**Test Result**
```
[hkx303@kuhuang scripts]$ export HYPERVISOR_TYPE=rhevm 
[hkx303@kuhuang scripts]$ export JOB_NAME=KuhuangTestJob
[hkx303@kuhuang scripts]$ export TRIGGER_TYPE=trigger-rhel 
[hkx303@kuhuang scripts]$ export JOB_NAME=runtest-rhevm

[hkx303@kuhuang scripts]$ python3 polarion_importer.py virtwho_xunit.xml 
2020-09-17 18:07:33 [INFO] https://polarion.engineering.redhat.com/polarion/#/project/RedHatEnterpriseLinux7/testrun?id=virtwho_runtest-rhevm_trigger-rhel_2020-09-17_18-31-03
2020-09-17 18:07:33 [INFO] ['name="nosetests" tests="103" errors="20" failures="0" skip="18"']
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 51841  100    81  100 51760     25  16074  0:00:03  0:00:03 --:--:-- 16099

2020-09-17 18:07:36 [INFO] {
  "files" : {
    "polarion.xml" : {
      "job-ids" : [ 1240845 ]
    }
  }
}

2020-09-17 18:07:36 [INFO] Successed to import xml to polarion
2020-09-17 18:07:36 [INFO] https://polarion.engineering.redhat.com/polarion/#/project/RedHatEnterpriseLinux7/testrun?id=virtwho_runtest-rhevm_trigger-rhel_2020-09-17_18-31-03

```


Can see some Run details in the Polarion as below:
https://polarion.engineering.redhat.com/polarion/#/project/RedHatEnterpriseLinux7/testrun?id=virtwho_runtest-rhevm_trigger-rhel_2020-09-17_18-31-03

![image](https://user-images.githubusercontent.com/46016760/93457757-fba6e300-f911-11ea-85bb-7deb53b39cd4.png)

