### PR TITLE
skip tc1002, tc1006 for scratch build

### DIFF
--- a/tests/tier1/tc_1002_check_virtwho_can_be_installed_and_uninstalled.py
+++ b/tests/tier1/tc_1002_check_virtwho_can_be_installed_and_uninstalled.py
@@ -10,6 +10,9 @@ class Testcase(Testing):
         trigger_type = self.get_config('trigger_type')
         if trigger_type in ('trigger-rhev', 'trigger-brew', 'trigger-multiarch'):
             self.vw_case_skip(trigger_type)
+        pkg_info = self.pkg_info(self.ssh_host(), 'virt-who')
+        if "none" in pkg_info.get("Signature"):
+            self.vw_case_skip('Scratch Build')
 
         # case config
         results = dict()

--- a/tests/tier1/tc_1006_run_virtwho_with_default_config.py
+++ b/tests/tier1/tc_1006_run_virtwho_with_default_config.py
@@ -11,6 +11,9 @@ class Testcase(Testing):
         hypervisor_type = self.get_config('hypervisor_type')
         if trigger_type in ('trigger-rhev', 'trigger-brew', 'trigger-multiarch'):
             self.vw_case_skip(trigger_type)
+        pkg_info = self.pkg_info(self.ssh_host(), 'virt-who')
+        if "none" in pkg_info.get("Signature"):
+            self.vw_case_skip('Scratch Build')
         self.vw_case_init()
 
         # case config


### PR DESCRIPTION
tc1002 and tc1006 are not available for scratch build, because we can not install the scratch build from yum, we install scratch package by manual.