### PR TITLE
Bug fix for tc1085

### DIFF
--- a/virt_who/register.py
+++ b/virt_who/register.py
@@ -225,6 +225,9 @@ class Register(Base):
             self.system_sku_refresh(ssh)
             cmd = "subscription-manager list --av --all --matches=%s | tail -n +4" % sku_id
             ret, output = self.runcmd(cmd, ssh, desc="subscription list matches")
+            if 'Failed to synchronize cache' in output:
+                logger.warning('Failed to synchronize cache for repo..., refer to bz1719177')
+                output = re.sub('Failed to synchronize.*ignoring this repo.', '', output).strip()
             if ret == 0 and not output and exp_exist is False:
                 logger.info("Succeeded to search, unexpected sku %s(%s) is not exist" % (sku_id, sku_type))
                 return output


### PR DESCRIPTION
subscription-manager list --av --all --matches=RH00049 | tail -n +4
Failed to synchronize cache for repo 'rhel8.0-appstream', ignoring this repo.
Failed to synchronize cache for repo 'rhel8.0-baseos', ignoring this repo.

This patch will ignore the above output to pass the case steps.

