### PR TITLE
update these cases for brew trigger testing

### DIFF
--- a/tests/tier1/tc_1001_check_virtwho_is_shipped_by_different_arch.py
+++ b/tests/tier1/tc_1001_check_virtwho_is_shipped_by_different_arch.py
@@ -11,9 +11,6 @@ class Testcase(Testing):
         compose_id = self.get_config('rhel_compose')
         if "trigger-rhel" not in trigger_type:
             self.vw_case_skip(trigger_type)
-        pkg_info = self.pkg_info(self.ssh_host(), 'virt-who')
-        if "none" in pkg_info.get("Signature"):
-            self.vw_case_skip('Scratch Build')
 
         # case config
         results = dict()

--- a/tests/tier1/tc_1002_check_virtwho_can_be_installed_and_uninstalled.py
+++ b/tests/tier1/tc_1002_check_virtwho_can_be_installed_and_uninstalled.py
@@ -10,9 +10,6 @@ class Testcase(Testing):
         trigger_type = self.get_config('trigger_type')
         if trigger_type in ('trigger-rhev', 'trigger-brew', 'trigger-multiarch'):
             self.vw_case_skip(trigger_type)
-        pkg_info = self.pkg_info(self.ssh_host(), 'virt-who')
-        if "none" in pkg_info.get("Signature"):
-            self.vw_case_skip('Scratch Build')
 
         # case config
         results = dict()

--- a/tests/tier1/tc_1006_run_virtwho_with_default_config.py
+++ b/tests/tier1/tc_1006_run_virtwho_with_default_config.py
@@ -11,9 +11,6 @@ class Testcase(Testing):
         hypervisor_type = self.get_config('hypervisor_type')
         if trigger_type in ('trigger-rhev', 'trigger-brew', 'trigger-multiarch'):
             self.vw_case_skip(trigger_type)
-        pkg_info = self.pkg_info(self.ssh_host(), 'virt-who')
-        if "none" in pkg_info.get("Signature"):
-            self.vw_case_skip('Scratch Build')
         self.vw_case_init()
 
         # case config


### PR DESCRIPTION
Because the trigger-brew job can be supported to run the scratch testing, if these cases are skipped for brew trigger, they will never be executed for scratch testing.