### PR TITLE
Added automation for BZ1844506

### DIFF
--- a/tests/tier1/tc_1110_send_virt-who_version_in_the_User-Agent_header.py
+++ b/tests/tier1/tc_1110_send_virt-who_version_in_the_User-Agent_header.py
@@ -1,0 +1,37 @@
+# coding:utf-8
+from virt_who import *
+from virt_who.base import Base
+from virt_who.register import Register
+from virt_who.testing import Testing
+
+
+class Testcase(Testing):
+    def test_run(self):
+        self.vw_case_info(os.path.basename(__file__), case_id='RHEL-195888')
+        if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] < '0.30.0':
+            self.vw_case_skip("virt-who version")
+        self.vw_case_init()
+
+        # case config
+        results = dict()
+        config_name = "virtwho-config"
+        config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
+        self.vw_etc_d_mode_create(config_name, config_file)
+
+        # case steps
+        logger.info('>>>step1: set the environment in the virt-who host and run virt-who service')
+        cmd = ('export SUBMAN_DEBUG_PRINT_REQUEST=1;'
+               'export SUBMAN_DEBUG_PRINT_REQUEST_HEADER=1')
+        cmd = "{0}; virt-who -o -c {1}".format(cmd, config_file)
+        data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
+        res1 = self.op_normal_value(data, exp_error=0, exp_thread=0, exp_send=1)
+        results.setdefault('step1', []).append(res1)
+
+        logger.info('>>>step2: check the message from console')
+        pkg = self.pkg_check(self.ssh_host(), 'virt-who')[9:17]
+        msg = 'virt-who/{}'.format(pkg)
+        res2 = self.vw_msg_search(output=tty_output, msg=pkg, exp_exist=True)
+        results.setdefault('step2', []).append(res2)
+
+        # case results
+        self.vw_case_result(results)

--- a/tests/tier1/tc_1110_send_virt-who_version_in_the_User-Agent_header.py
+++ b/tests/tier1/tc_1110_send_virt-who_version_in_the_User-Agent_header.py
@@ -30,7 +30,7 @@ class Testcase(Testing):
         logger.info('>>>step2: check the message from console')
         pkg = self.pkg_check(self.ssh_host(), 'virt-who')[9:17]
         msg = 'virt-who/{}'.format(pkg)
-        res2 = self.vw_msg_search(output=tty_output, msg=pkg, exp_exist=True)
+        res2 = self.vw_msg_search(output=tty_output, msg=msg, exp_exist=True)
         results.setdefault('step2', []).append(res2)
 
         # case results


### PR DESCRIPTION
**Description**
Added automation for [BZ1844506](https://bugzilla.redhat.com/show_bug.cgi?id=1844506)

**Test Result**
```
[hkx303@kuhuang tier1]$ nosetests tc_1110_send_virt-who_version_in_the_User-Agent_header.py 
2020-11-12 17:55:27 [INFO] ++++++++++++++++++++++++++++++
2020-11-12 17:55:27 [INFO] RHEL-195888:tc_1110_send_virt-who_version_in_the_User-Agent_header.py
2020-11-12 17:56:36 [INFO] Succeeded to get esxi host uuid: fb190dad-6c28-4589-b2fd-010e966be842
2020-11-12 17:56:46 [INFO] Succeeded to get satellite host_id: bootp-73-131-167.rhts.eng.pek2.redhat.com:781
2020-11-12 17:56:49 [INFO] Succeeded to delete host: bootp-73-131-167.rhts.eng.pek2.redhat.com
2020-11-12 17:56:56 [INFO] Succeeded to unregister and clean system(10.73.131.237:52223)
2020-11-12 17:57:12 [INFO] Succeeded to register system 10.73.131.237:52223 to ent-02-vm-03.lab.eng.nay.redhat.com(satellite68-dogfood-rhel7)
2020-11-12 17:57:21 [INFO] Succeeded to unregister and clean system(10.73.131.205)
2020-11-12 17:57:48 [INFO] Succeeded to register system 10.73.131.205 to ent-02-vm-03.lab.eng.nay.redhat.com(satellite68-dogfood-rhel7)
2020-11-12 17:57:51 [INFO] Succeeded to disable all options in /etc/virt-who.conf
2020-11-12 17:57:52 [INFO] Succeeded to disable all options in /etc/sysconfig/virt-who
2020-11-12 17:57:53 [INFO] Succeeded to delete all files in /etc/virt-who.d/
2020-11-12 17:57:56 [INFO] Succeeded to create config file /etc/virt-who.d/virtwho-config.conf
2020-11-12 17:57:56 [INFO] >>>step1: set the environment in the virt-who host and run virt-who service
2020-11-12 17:58:11 [INFO] Start to run virt-who by cli: export SUBMAN_DEBUG_PRINT_REQUEST=1;export SUBMAN_DEBUG_PRINT_REQUEST_HEADER=1; virt-who -o -c /etc/virt-who.d/virtwho-config.conf
2020-11-12 17:58:36 [INFO] pending_job: 0, is_429: no, loop_num: 0, loop_time: -1, send_num: 1, error_num: 0, thread_num: 0
2020-11-12 17:58:36 [INFO] virt-who is terminated by pid exit
2020-11-12 17:58:51 [INFO] virtwho thread number(0) is expected
2020-11-12 17:58:51 [INFO] virtwho error number(0) is expected
2020-11-12 17:58:51 [INFO] virtwho send number(1) is expected
2020-11-12 17:58:51 [INFO] Finished to validate all the expected options
2020-11-12 17:58:51 [INFO] >>>step2: check the message from console
2020-11-12 17:58:53 [INFO] Succeeded to search, expected msg(virt-who/0.30.1-1) is exist(6)
2020-11-12 17:58:53 [INFO] Succeeded to run case, all steps passed

.
----------------------------------------------------------------------
Ran 1 test in 206.249s

OK
```
