### PR TITLE
fix libvirt local installation issue

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -955,10 +955,10 @@ class Provision(Register):
         ret, output = self.runcmd(cmd, ssh_host)
         if "RHEL-7" in compose_id:
             cmd = "yum clean all; yum install -y @core @x11 net-tools virt-who wget git nmap \
-                    subscription-manager-gui pexpect expect libvirt-python"
+                    subscription-manager pexpect expect libvirt-python"
         else:
             cmd = "yum clean all; yum install -y @core @base-x net-tools virt-who wget git nmap expect \
-                    subscription-manager subscription-manager-cockpit python3-pexpect python3-libvirt network-scripts"
+                    subscription-manager python3-pexpect python3-libvirt"
         status, output = self.run_loop(cmd, ssh_host, desc="install base required packages")
         if status != "Yes":
             raise FailException("Failed to install base required packages")


### PR DESCRIPTION
Fix the job: https://main-jenkins-csb-virtwhoqe.cloud.paas.psi.redhat.com/job/trigger-rhel/10/console 

2020-12-22 01:18:57 [ERROR] Failed to install base required packages
Exception in thread Thread-8:
Traceback (most recent call last):
  File "/usr/lib64/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/jenkins/workspace/trigger-rhel/virtwho-ci/virt_who/provision.py", line 373, in provision_libvirt_local_host
    self.rhel_install_by_grub(ssh_libvirt, compose_id)
  File "/home/jenkins/workspace/trigger-rhel/virtwho-ci/virt_who/provision.py", line 1195, in rhel_install_by_grub
    self.install_base_packages(ssh_host)
  File "/home/jenkins/workspace/trigger-rhel/virtwho-ci/virt_who/provision.py", line 964, in install_base_packages
    raise FailException("Failed to install base required packages")
virt_who.FailException: Failed to install base required packages
