### PR TITLE
Remove -c option for tc_1110

### DIFF
--- a/tests/tier1/tc_1110_send_virt-who_version_in_the_User-Agent_header.py
+++ b/tests/tier1/tc_1110_send_virt-who_version_in_the_User-Agent_header.py
@@ -22,7 +22,7 @@ class Testcase(Testing):
         logger.info('>>>step1: set the environment in the virt-who host and run virt-who service')
         cmd = ('export SUBMAN_DEBUG_PRINT_REQUEST=1;'
                'export SUBMAN_DEBUG_PRINT_REQUEST_HEADER=1')
-        cmd = "{0}; virt-who -o -c {1}".format(cmd, config_file)
+        cmd = "{0}; virt-who -o".format(cmd)
         data, tty_output, rhsm_output = self.vw_start(cmd, exp_send=1)
         res1 = self.op_normal_value(data, exp_error=0, exp_thread=0, exp_send=1)
         results.setdefault('step1', []).append(res1)


### PR DESCRIPTION
The case was failed for local libvirt mode due to no config_file creating for this mode when run "virt-who -o -c".
There is no need for the -c option because the config_file is already in /etc/virt-who.d/, "virt-who -o" can run the configurations.
So we remove the option.
```
# pytest-3 tests/tier1/tc_1110_send_virt-who_version_in_the_User-Agent_header.py 
================== test session starts ==================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.1
rootdir: /root/workspace/virtwho-ci, inifile:
plugins: xdist-1.27.0, forked-1.0.1, flake8-1.0.1, mock-1.10.4
collected 1 item                                                                                                                                                                                  

============= 1 passed, 6 warnings in 122.83 seconds ================
```