### PR TITLE
update tc2013 due to bz1739358 wontfix

### DIFF
--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -92,7 +92,10 @@ class Testcase(Testing):
         # Case Result
         self.vw_case_result(results)
 
-        '''WONTFI bz1716337 - virt-who doesn't connect all hypervisors by proxy'''
+        '''WONTFIX bz1739358 - [XEN] virt-who can send mapping to server but always print 
+        errors when bad http(s)_proxy and good no_proxy values are configured'''
+
+        '''WONTFIX bz1716337 - virt-who doesn't connect all hypervisors by proxy'''
 
         '''
         For below scenarios, virt-who connect hypervisor not by proxy.

--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -80,21 +80,17 @@ class Testcase(Testing):
             self.vw_option_enable("rhsm_no_proxy", vw_conf)
             self.vw_option_update_value("rhsm_no_proxy", register_server, vw_conf)
             data, tty_output, rhsm_output = self.vw_start(exp_send=1)
-            res3 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+            if hypervisor_type == 'xen':
+                res3 = self.op_normal_value(data, exp_error=2, exp_thread=1, exp_send=1)
+            else:
+                res3 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
             results.setdefault('step2', []).append(res3)
             self.vw_option_del('no_proxy', sysconfig_file)
             self.vw_option_del(option, sysconfig_file)
             self.vw_option_disable('rhsm_no_proxy', vw_conf)
 
         # Case Result
-        notes = list()
-        if hypervisor_type == 'xen':
-            notes.append("(step2) [XEN] Print errors when send mapping")
-            if "RHEL-8" in compose_id:
-                notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1739358")
-            elif "RHEL-7" in compose_id:
-                notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1764004")
-        self.vw_case_result(results, notes)
+        self.vw_case_result(results)
 
         '''WONTFI bz1716337 - virt-who doesn't connect all hypervisors by proxy'''
 


### PR DESCRIPTION
bz1739358 wontfix for xen mode, so update code to pass the case.
```
# pytest-3 tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py 
=========================== test session starts ===========================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.1
rootdir: /root/workspace/virtwho-ci, inifile:
plugins: xdist-1.27.0, forked-1.0.1, flake8-1.0.1, mock-1.10.4
collected 1 item                                                                                                                                                                                  

tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py .                   [100%]

======================== 1 passed, 6 warnings in 410.88 seconds ========================
```