### PR TITLE
Fixes for RHEL-9.0.0-20210105.3 test run

### DIFF
--- a/tests/tier2/tc_2001_validate_owner_option_by_cli.py
+++ b/tests/tier2/tc_2001_validate_owner_option_by_cli.py
@@ -9,10 +9,10 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136568')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
-        compose_id = self.get_config('rhel_compose')
-        if "RHEL-8" in compose_id:
+        if "RHEL-7" not in compose_id:
             self.vw_case_skip(compose_id)
         self.vw_case_init()
 

--- a/tests/tier2/tc_2003_validate_server_option_by_cli.py
+++ b/tests/tier2/tc_2003_validate_server_option_by_cli.py
@@ -12,8 +12,8 @@ class Testcase(Testing):
         compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
             self.vw_case_skip(hypervisor_type)
-        if "RHEL-8" in compose_id:
-            self.vw_case_skip("RHEL-8")
+        if "RHEL-7" not in compose_id:
+            self.vw_case_skip(compose_id)
         self.vw_case_init()
 
         # Case Config

--- a/tests/tier2/tc_2004_validate_username_option_by_cli.py
+++ b/tests/tier2/tc_2004_validate_username_option_by_cli.py
@@ -12,8 +12,8 @@ class Testcase(Testing):
         compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
             self.vw_case_skip(hypervisor_type)
-        if "RHEL-8" in compose_id:
-            self.vw_case_skip("RHEL-8")
+        if "RHEL-7" not in compose_id:
+            self.vw_case_skip(compose_id)
         self.vw_case_init()
 
         # Case Config

--- a/tests/tier2/tc_2005_validate_password_option_by_cli.py
+++ b/tests/tier2/tc_2005_validate_password_option_by_cli.py
@@ -12,8 +12,8 @@ class Testcase(Testing):
         compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm', 'kubevirt'):
             self.vw_case_skip(hypervisor_type)
-        if "RHEL-8" in compose_id:
-            self.vw_case_skip("RHEL-8")
+        if "RHEL-7" not in compose_id:
+            self.vw_case_skip(compose_id)
         self.vw_case_init()
 
         # Case Config

--- a/tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py
+++ b/tests/tier2/tc_2007_validate_parameters_consistency_by_cli.py
@@ -12,8 +12,8 @@ class Testcase(Testing):
         compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
-        if "RHEL-8" in compose_id:
-            self.vw_case_skip("RHEL-8")
+        if "RHEL-7" not in compose_id:
+            self.vw_case_skip(compose_id)
         self.vw_case_init()
 
         # Case Config

--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -14,6 +14,9 @@ class Testcase(Testing):
             self.vw_case_skip("virt-who version")
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
+        '''http_proxy, no_proxy are moved to /etc/virt-who.conf, will not test this exception for rhel9'''
+        if "RHEL-9" in compose_id:
+            self.vw_case_skip(compose_id)
         self.vw_case_init()
 
         # Case Config

--- a/tests/tier2/tc_2017_validate_env_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2017_validate_env_option_in_etc_virtwho_d.py
@@ -8,10 +8,14 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136588')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         if self.pkg_check(self.ssh_host(), 'virt-who')[9:15] >= '0.24.6':
             self.vw_case_skip("virt-who version")
+        '''env was not supported by rhel8 and rhel9 any more'''
+        if "RHEL-7" not in compose_id:
+            self.vw_case_skip(compose_id)
         self.vw_case_init()
 
         # Case Config

--- a/tests/tier2/tc_2018_validate_server_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2018_validate_server_option_in_etc_virtwho_d.py
@@ -44,7 +44,7 @@ class Testcase(Testing):
         logger.info(">>>step3: server option is 红帽€467aa value")
         self.vw_option_update_value(option_tested, '红帽€467aa', config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        if "RHEL-8" in compose_id and "esx" in hypervisor_type:
+        if "RHEL-7" not in compose_id and "esx" in hypervisor_type:
             msg = "Option server needs to be ASCII characters only"
             res1 = self.op_normal_value(data, exp_error="1|2|3", exp_thread=0, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, msg, exp_exist=True)

--- a/tests/tier2/tc_2035_validate_global_report_id_by_virtwho_conf.py
+++ b/tests/tier2/tc_2035_validate_global_report_id_by_virtwho_conf.py
@@ -56,4 +56,6 @@ class Testcase(Testing):
         notes = list()
         notes.append("Bug(step2): virt-who still uses null value for reporter_id")
         notes.append("BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1750206")
+        notes.append("Bug(step3): error when configured the report_id with special")
+        notes.append("BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1910274")
         self.vw_case_result(results, notes)

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -955,10 +955,10 @@ class Provision(Register):
         ret, output = self.runcmd(cmd, ssh_host)
         if "RHEL-7" in compose_id:
             cmd = "yum clean all; yum install -y @core @x11 net-tools virt-who wget git nmap \
-                    subscription-manager pexpect expect libvirt-python"
+                    hostname subscription-manager pexpect expect libvirt-python"
         else:
             cmd = "yum clean all; yum install -y @core @base-x net-tools virt-who wget git nmap expect \
-                    subscription-manager python3-pexpect python3-libvirt"
+                    hostname subscription-manager python3-pexpect python3-libvirt"
         status, output = self.run_loop(cmd, ssh_host, desc="install base required packages")
         if status != "Yes":
             raise FailException("Failed to install base required packages")


### PR DESCRIPTION
This PR is used to fixed the failed cases for RHEL-9.0.0-20210105.3 testing.
Basically:
some cases are invalid for rhel9
some cases are invalid for stage
libvirt local provision failed because hostname package was not installed.