### PR TITLE
Update tc1004 to fix bz1879329

### DIFF
--- a/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
+++ b/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
@@ -19,6 +19,8 @@ class Testcase(Testing):
         logger.info(">>>step2: virt-who-config have correct man page")
         ret, output = self.runcmd("man virt-who-config", self.ssh_host())
         results.setdefault('step2', []).append("configuration for virt-who" in output)
+        msg1 = "backend names: libvirt, esx, rhevm, hyperv, fake, xen, or kube.*\n.*virt"
+        results.setdefault('step2', []).append(self.vw_msg_search(output, msg1))
 
         logger.info(">>>step3: virt-who have correct help page")
         ret, output = self.runcmd("virt-who --help", self.ssh_host())

--- a/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
+++ b/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
@@ -19,8 +19,8 @@ class Testcase(Testing):
         logger.info(">>>step2: virt-who-config have correct man page")
         ret, output = self.runcmd("man virt-who-config", self.ssh_host())
         results.setdefault('step2', []).append("configuration for virt-who" in output)
-        msg1 = "backend names: libvirt, esx, rhevm, hyperv, fake, xen, or kube.*\n.*virt"
-        results.setdefault('step2', []).append(self.vw_msg_search(output, msg1))
+        msg = "backend names: libvirt, esx, rhevm, hyperv, fake, xen, or kube.*\n.*virt"
+        results.setdefault('step2', []).append(self.vw_msg_search(output, msg))
 
         logger.info(">>>step3: virt-who have correct help page")
         ret, output = self.runcmd("virt-who --help", self.ssh_host())


### PR DESCRIPTION
The outputs are separated to different lines after remote running "man virt-who-connfig" by ssh, which problem also exists with ssh remote running "man virt-who-config|grep", so used wildcard at last. 
```
# pytest-3 tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py 
================= test session starts =================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.1
rootdir: /root/workspace/virtwho-ci, inifile:
plugins: xdist-1.27.0, forked-1.0.1, flake8-1.0.1, mock-1.10.4
collected 1 item                                                                                                                                                                                  

tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py .                                                                                                                [100%]
================== 1 passed, 6 warnings in 2.66 seconds =================
```