### PR TITLE
New functions for using API to connect Openshift+CNV

### DIFF
--- a/utils/installer.py
+++ b/utils/installer.py
@@ -258,9 +258,9 @@ def setup_libvirt():
 
 
 def setup_kubevirt():
-    master = deploy.kubevirt.master
-    master_username = deploy.kubevirt.master_user
-    master_password = deploy.kubevirt.master_passwd
+    master = deploy.kubevirt.endpoint
+    master_username = ''
+    master_password = deploy.kubevirt.token
     guest_name = deploy.kubevirt.guest_name
     guest_username = deploy.kubevirt.guest_user
     guest_password = deploy.kubevirt.guest_passwd
@@ -268,7 +268,7 @@ def setup_kubevirt():
         'host': master,
         'username': master_username,
         'password': master_password}
-    guest = provision.kubevirt_guest_ip(ssh_master, guest_name)
+    guest = provision.kubevirt_guest_ip(guest_name)
     if guest:
         ssh_guest = {
             'host': guest,

--- a/utils/installer.py
+++ b/utils/installer.py
@@ -264,10 +264,6 @@ def setup_kubevirt():
     guest_name = deploy.kubevirt.guest_name
     guest_username = deploy.kubevirt.guest_user
     guest_password = deploy.kubevirt.guest_passwd
-    ssh_master ={
-        'host': master,
-        'username': master_username,
-        'password': master_password}
     guest = provision.kubevirt_guest_ip(guest_name)
     if guest:
         ssh_guest = {

--- a/virt_who/__init__.py
+++ b/virt_who/__init__.py
@@ -12,6 +12,10 @@ import socket
 import select
 import threading
 import paramiko
+import urllib3
+from six import PY3
+from urllib3.util.timeout import Timeout
+urllib3.disable_warnings()
 
 try:
    import queue

--- a/virt_who/settings.py
+++ b/virt_who/settings.py
@@ -544,9 +544,8 @@ class SetLibvirt(FeatureSettings):
 class SetKubevirt(FeatureSettings):
     def __init__(self, *args, **kwargs):
         super(SetKubevirt, self).__init__(*args, **kwargs)
-        self.master = None
-        self.master_user = None
-        self.master_passwd = None
+        self.endpoint = None
+        self.token = None
         self.guest_name = None
         self.guest_user = None
         self.guest_passwd = None
@@ -555,9 +554,8 @@ class SetKubevirt(FeatureSettings):
         self.kube_config_url = None
 
     def read(self, reader):
-        self.master = reader.get('kubevirt', 'master')
-        self.master_user = reader.get('kubevirt', 'master_user')
-        self.master_passwd = reader.get('kubevirt', 'master_passwd')
+        self.endpoint = reader.get('kubevirt', 'endpoint')
+        self.token = reader.get('kubevirt', 'token')
         self.guest_name = reader.get('kubevirt', 'guest_name')
         self.guest_user = reader.get('kubevirt', 'guest_user')
         self.guest_passwd = reader.get('kubevirt', 'guest_passwd')

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -213,7 +213,7 @@ class Testing(Provision):
         if hypervisor_type == "xen":
             hostname = self.get_hostname(ssh_hypervisor)
         if hypervisor_type == "kubevirt":
-            hostname = self.kubevirt_guest_node_name(ssh_hypervisor, guest_name)
+            hostname = self.kubevirt_guest_attrs(guest_name)['guest_node']
         if hypervisor_type == "rhevm":
             rhevm_shell, rhevm_shellrc = self.rhevm_shell_get(ssh_hypervisor)
             hostname = self.rhevm_host_name_by_guestname(ssh_hypervisor, rhevm_shell, guest_name)
@@ -240,8 +240,8 @@ class Testing(Provision):
         if hypervisor_type == "xen":
             uuid = self.xen_host_uuid(ssh_hypervisor)
         if hypervisor_type == "kubevirt":
-            node_name = self.kubevirt_guest_node_name(ssh_hypervisor, guest_name)
-            uuid = self.kubevirt_host_uuid(ssh_hypervisor, node_name)
+            node_name = self.kubevirt_guest_attrs(guest_name)['guest_node']
+            uuid = self.kubevirt_host_attrs(node_name)['host_uuid']
         if hypervisor_type == "libvirt-local":
             uuid = self.libvirt_host_uuid(self.ssh_host())
         if hypervisor_type == "libvirt-remote":
@@ -282,7 +282,7 @@ class Testing(Provision):
         if hypervisor_type == "xen":
             uuid = self.xen_guest_uuid(ssh_hypervisor, guest_name)
         if hypervisor_type == "kubevirt":
-            uuid = self.kubevirt_guest_uuid(ssh_hypervisor, guest_name)
+            uuid = self.kubevirt_guest_attrs(guest_name)['guest_id']
         if hypervisor_type == "libvirt-local":
             uuid = self.libvirt_guest_uuid(guest_name, self.ssh_host())
         if hypervisor_type == "libvirt-remote":


### PR DESCRIPTION
With the new functions, it's easy get the attributes for guest and its worker node.
A demo as:
```
from virt_who import *
from virt_who.base import Base
from virt_who.register import Register
from virt_who.provision import Provision

class RunProvision(Provision):
    def test_run(self):
        guest_name = 'rhel83-vm'
        version = self.kubevirt_version()
        guest_attrs = self.kubevirt_guest_attrs(guest_name)
        host_attrs = self.kubevirt_host_attrs(guest_attrs['guest_node'])
        guest_ip = self.kubevirt_guest_ip(guest_name)
        logger.info(version)
        logger.info(guest_attrs)
        logger.info(host_attrs)
        logger.info(guest_ip)

if __name__ == "__main__":
    unittest.main()
```

The output as:
```
# nosetests-3 demo.py
2021-01-21 22:59:59 [INFO] v1alpha3
2021-01-21 22:59:59 [INFO] {'guest_id': '1a559ee9-9aa4-5d2d-bc6c-ecdb8d8c8d28', 'guest_node': 'worker-1.virtwho1.lab.upshift.rdu2.redhat.com', 'guest_status': 'Running'}
2021-01-21 22:59:59 [INFO] {'host_uuid': '09cf0137bde545eb885bcadda61c84e2', 'host_name': 'worker-1.virtwho1.lab.upshift.rdu2.redhat.com'}
2021-01-21 22:59:59 [INFO] worker-1.virtwho1.lab.upshift.rdu2.redhat.com:32516
```