### PR TITLE
add urllib3 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+urllib3
 paramiko==2.4.2
 requests==2.20.1
 unittest2==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,11 @@
-urllib3
-paramiko==2.4.2
-requests==2.20.1
+attrdict==2.0.1
+paramiko==2.5.0
+pytest==5.4.3
+pytest-services==1.3.1
+pytest-mock==1.10.4
+pytest-xdist==1.34.0
+requests==2.22.0
 unittest2==1.1.0
+urllib3==1.25.3
+PyYAML==5.1.2
+pexpect==4.7.0


### PR DESCRIPTION
Below issue occured after the the last merged pr https://github.com/VirtwhoQE/virtwho-ci/pull/132/ 
So add urllib3 to requirements.txt

```
  File "/home/jenkins/workspace/runtest-esx/virtwho-ci/virt_who/__init__.py", line 15, in <module>
    import urllib3
ModuleNotFoundError: No module named 'urllib3'
```