### PR TITLE
Added automation for BZ1855550

### DIFF
--- a/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
@@ -40,15 +40,31 @@ class Testcase(Testing):
             results.setdefault(step, []).append(s1)
             if option == "hwuuid":
                 hypervisorId = host_hwuuid
+                hypervisor_display = host_hwuuid
             elif option == "hostname":
                 hypervisorId = host_name
+                hypervisor_display = host_name
             else:
                 hypervisorId = host_uuid
+                hypervisor_display = host_uuid
             if hypervisorId in data[register_owner].keys():
                 logger.info("Succeeded to search hypervisorId:{0}".format(hypervisorId))
                 results.setdefault(step, []).append(True)
             else:
                 logger.error("Failed to search hypervisorId:{0}".format(hypervisorId))
+                results.setdefault(step, []).append(False)
+            if 'satellite' in register_type:
+                host_display = self.satellite_host_display(self.ssh_host(), register_config,
+                                        host_name, host_uuid, host_hwuuid)
+            else:
+                hypervisor_display = host_name
+                host_display = self.stage_consumer_display(self.ssh_host(), register_config,
+                                        host_name, host_uuid, retry=True)
+            if hypervisor_display in host_display:
+                logger.info("Succeeded to search hypervisorDisplay:{0}".format(hypervisor_display))
+                results.setdefault(step, []).append(True)
+            else:
+                logger.error("Failed to search hypervisorDisplay:{0}".format(hypervisor_display))
                 results.setdefault(step, []).append(False)
             self.vw_option_del("hypervisor_id", filename=config_file)
             self.vw_web_host_delete(host_name, hypervisorId)

--- a/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
@@ -54,13 +54,15 @@ class Testcase(Testing):
                 logger.error("Failed to search hypervisorId:{0}".format(hypervisorId))
                 results.setdefault(step, []).append(False)
             if 'satellite' in register_type:
-                host_display = self.satellite_host_display(self.ssh_host(), register_config,
-                                        host_name, host_uuid, host_hwuuid)
+                host_display = self.satellite_hosts_get(self.ssh_host(), register_config,
+                                        host_name, host_uuid, host_hwuuid, desc="get host display name")
+                host_display_name = host_display['name']
             else:
                 hypervisor_display = host_name
                 host_display = self.stage_consumer_display(self.ssh_host(), register_config,
                                         host_name, host_uuid, retry=True)
-            if hypervisor_display in host_display:
+                host_display_name = host_display['name']
+            if hypervisor_display in host_display_name:
                 logger.info("Succeeded to search hypervisorDisplay:{0}".format(hypervisor_display))
                 results.setdefault(step, []).append(True)
             else:

--- a/tests/tier2/tc_2046_check_registered_by_item_in_satellite_webui.py
+++ b/tests/tier2/tc_2046_check_registered_by_item_in_satellite_webui.py
@@ -50,10 +50,10 @@ class Testcase(Testing):
             logger.info(">>>exp:{0}".format(exp))
             if check_type == "hypervisor":
                 output = self.satellite_hosts_get(self.ssh_host(), register_config,
-                                                  host_name, host_uuid, "get hypervisor info")
+                                                  host_name, host_uuid, desc="get hypervisor info")
             else:
                 output = self.satellite_hosts_get(self.ssh_host(), register_config,
-                                                  guest_name, guest_uuid, "get guest info")
+                                                  guest_name, guest_uuid, desc="get guest info")
             if output is not None:
                 user = output["subscription_facet_attributes"]["user"]
                 if user is not False and user is not None and 'login' in user.keys():

--- a/tests/tier2/tc_2066_validate_cluster_name_with_special_char.py
+++ b/tests/tier2/tc_2066_validate_cluster_name_with_special_char.py
@@ -49,7 +49,7 @@ class Testcase(Testing):
 
             logger.info(">>>step3: check the hyperivsor fact by hammer command")
             output = self.satellite_hosts_get(self.ssh_host(), register_config,
-                                              host_name, host_uuid, "get hypervisor info")
+                                              host_name, host_uuid, desc="get hypervisor info")
             cmd = "hammer host facts --name {}".format(output['name'])
             _, result = self.runcmd(cmd, ssh_register)
 

--- a/virt_who/register.py
+++ b/virt_who/register.py
@@ -884,10 +884,9 @@ class Register(Base):
             return None
 
     def satellite_host_display(self, ssh, register_config, host_name, host_uuid, host_hwuuid=None,
-                               desc="get host dispaly name"):
+                               desc="get host display name"):
         output = self.satellite_hosts_get(ssh, register_config, host_name, host_uuid, host_hwuuid, desc)
         return output['name']
-
 
     def satellite_active_key_create(self, ssh, register_config, key_name, org_id=1, desc=""):
         api = register_config['api']

--- a/virt_who/register.py
+++ b/virt_who/register.py
@@ -513,7 +513,7 @@ class Register(Base):
             if ret == 0 and output is not False and output is not None:
                 output = self.is_json(output.strip())
                 logger.info("Succeeded to get host display info :{0}".format(output['name']))
-            return output['name']
+            return output
         else:
             logger.info("Failed to get host display info")
 
@@ -882,11 +882,6 @@ class Register(Base):
         else:
             logger.info("Failed to get host info")
             return None
-
-    def satellite_host_display(self, ssh, register_config, host_name, host_uuid, host_hwuuid=None,
-                               desc="get host display name"):
-        output = self.satellite_hosts_get(ssh, register_config, host_name, host_uuid, host_hwuuid, desc)
-        return output['name']
 
     def satellite_active_key_create(self, ssh, register_config, key_name, org_id=1, desc=""):
         api = register_config['api']


### PR DESCRIPTION
**Description**
Added automation for [BZ1855550](https://bugzilla.redhat.com/show_bug.cgi?id=1855550)

- [x] Update `satellite_host_id` function
- [x] Add `satellite_host_display` function
- [x] Add `stage_consumer_display` function
- [x] Update related cases



**Test Result**

- For Satellite6.8 Esx hypervisor

```
[hkx303@kuhuang tier1]$ pytest tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-ci/tests/tier1
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item       
========================= 1 passed, 12 warnings in 411.43s (0:06:51) =========================
```
- For Stage Esx hypervisor

```
[hkx303@kuhuang tier1]$ pytest tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-ci/tests/tier1
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item 
========================= 1 passed, 1 warning in 642.65s (0:10:42) ==========================
```
