### PR TITLE
tc2066 fix code issue

### DIFF
--- a/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
@@ -59,8 +59,8 @@ class Testcase(Testing):
                 host_display_name = host_display['name']
             else:
                 hypervisor_display = host_name
-                host_display = self.stage_consumer_display(self.ssh_host(), register_config,
-                                        host_name, host_uuid, retry=True)
+                host_display = self.stage_consumer_get(self.ssh_host(), register_config,
+                                        host_name, host_uuid)
                 host_display_name = host_display['name']
             if hypervisor_display in host_display_name:
                 logger.info("Succeeded to search hypervisorDisplay:{0}".format(hypervisor_display))

--- a/tests/tier2/tc_2066_validate_cluster_name_with_special_char.py
+++ b/tests/tier2/tc_2066_validate_cluster_name_with_special_char.py
@@ -9,6 +9,7 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-196078')
         hypervisor_type = self.get_config('hypervisor_type')
+        register_type = self.get_config('register_type')
         if hypervisor_type != 'esx':
             self.vw_case_skip(hypervisor_type)
         self.vw_case_init()
@@ -45,16 +46,22 @@ class Testcase(Testing):
             logger.info(">>>step2: run virt-who service with the new cluster name")
             data, tty_output, rhsm_output = self.vw_start(exp_error=0, exp_send=1)
             res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
+            res2 = self.vw_msg_search(rhsm_output, '"hypervisor.cluster": "{0}"'.format(new_cluster_name))
             results.setdefault('step2', []).append(res1)
+            results.setdefault('step2', []).append(res2)
 
-            logger.info(">>>step3: check the hyperivsor fact by hammer command")
-            output = self.satellite_hosts_get(self.ssh_host(), register_config,
-                                              host_name, host_uuid, desc="get hypervisor info")
-            cmd = "hammer host facts --name {}".format(output['name'])
-            _, result = self.runcmd(cmd, ssh_register)
-
-            self.vw_msg_search(result, new_cluster_name)
-            self.vw_msg_search(result, cluster_name, False)
+            logger.info(">>>step3: check the hyperivsor facts")
+            if "satelltie" in register_type:
+                output = self.satellite_hosts_get(self.ssh_host(), register_config,
+                                                  host_name, host_uuid, desc="get hypervisor info")
+                cmd = "hammer host facts --name {}".format(output['name'])
+                _, result = self.runcmd(cmd, ssh_register)
+            else:
+                output = self.stage_consumer_get(self.ssh_host(), register_config,
+                                                 host_name, host_uuid, desc="get hypervisor info")
+                result = output['facts']['hypervisor.cluster']
+            res = self.vw_msg_search(result, new_cluster_name)
+            results.setdefault('step3', []).append(res)
 
         finally:
             logger.info(">>>step finally: change back the vcenter cluster name")

--- a/tests/tier2/tc_2066_validate_cluster_name_with_special_char.py
+++ b/tests/tier2/tc_2066_validate_cluster_name_with_special_char.py
@@ -51,7 +51,7 @@ class Testcase(Testing):
             results.setdefault('step2', []).append(res2)
 
             logger.info(">>>step3: check the hyperivsor facts")
-            if "satelltie" in register_type:
+            if "satellite" in register_type:
                 output = self.satellite_hosts_get(self.ssh_host(), register_config,
                                                   host_name, host_uuid, desc="get hypervisor info")
                 cmd = "hammer host facts --name {}".format(output['name'])

--- a/virt_who/register.py
+++ b/virt_who/register.py
@@ -501,15 +501,15 @@ class Register(Base):
             logger.info("Host({0}) is not found in stage server".format(host_name))
         return True
 
-    def stage_consumer_display(self, ssh, register_config, host_name, host_uuid, retry=True):
+    def stage_consumer_get(self, ssh, register_config, host_name, host_uuid, desc=""):
         api = register_config['api']
         username = register_config['username']
         password = register_config['password']
-        consumer_uuid = self.stage_consumer_uuid(ssh, register_config, host_name, host_uuid, retry)
+        consumer_uuid = self.stage_consumer_uuid(ssh, register_config, host_name, host_uuid, True)
         if consumer_uuid is not None and consumer_uuid != "":
             cmd = "curl -s -k -u {0}:{1} -X GET {2}/consumers/{3}".format(
                     username, password, api, consumer_uuid)
-            ret, output = self.runcmd(cmd, ssh)
+            ret, output = self.runcmd(cmd, ssh, desc=desc)
             if ret == 0 and output is not False and output is not None:
                 output = self.is_json(output.strip())
                 logger.info("Succeeded to get host display info :{0}".format(output['name']))


### PR DESCRIPTION
Add branch for testing against stage candlepin.
Locally run passed with both satellite and stage.
```
# pytest-3 tests/tier2/tc_2066_validate_cluster_name_with_special_char.py 
======================== test session starts ========================
platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.1
rootdir: /root/workspace/virtwho-ci, inifile:
plugins: xdist-1.27.0, forked-1.0.1, flake8-1.0.1, services-1.3.1, mock-1.10.4
collected 1 item                                                                                                                                                                                  

tests/tier2/tc_2066_validate_cluster_name_with_special_char.py .                                                                                                                            [100%]

============== 1 passed, 2 warnings in 330.44 seconds =======================
```