### PR TITLE
Fix tc_1052 for rhevm and hyperv modes

### DIFF
--- a/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
@@ -62,7 +62,7 @@ class Testcase(Testing):
                 host_display = self.stage_consumer_get(self.ssh_host(), register_config,
                                         host_name, host_uuid)
                 host_display_name = host_display['name']
-            if hypervisor_display in host_display_name:
+            if hypervisor_display or hypervisor_display.lower() in host_display_name:
                 logger.info("Succeeded to search hypervisorDisplay:{0}".format(hypervisor_display))
                 results.setdefault(step, []).append(True)
             else:


### PR DESCRIPTION
**Description**
Fix #147 

**Test Result**
```
[hkx303@kuhuang virtwho-ci]$ pytest tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item                                                                             

tests/tier1/tc_1052_check_hypervisor_id_option_in_etc_virtwho_d.py .                   [100%]
========================= 1 passed, 6 warnings in 300.21s (0:05:00) ==========================
```