### PR TITLE
Add satellite 6.10 support for virt-who plugin

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1295,7 +1295,9 @@ class Provision(Register):
         return job_passed
 
     def satellite_version(self, sat_type):
-        if "6.9" in sat_type or "69" in sat_type:
+        if "6.10" in sat_type or "610" in sat_type:
+            sat_ver = "6.10"
+        elif "6.9" in sat_type or "69" in sat_type:
             sat_ver = "6.9"
         elif "6.8" in sat_type or "68" in sat_type:
             sat_ver = "6.8"


### PR DESCRIPTION
Add satellite 6.10 support for virt-who plugin to fix the error:
`virt_who.FailException: Unknown satellite version`