### PR TITLE
Remove the ".0" from activationkey to fix statellite installing error

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1361,9 +1361,7 @@ class Provision(Register):
             ret, output = self.runcmd(cmd, ssh_sat, desc="uninstall katello-ca-consumer")
             cmd = "yum -y localinstall {0}".format(repo)
             ret, output = self.runcmd(cmd, ssh_sat, desc="install katello-ca")
-            cmd = "subscription-manager register --org Sat6-CI --activationkey '%s-%s.0-qa-rhel%s'" % (repo_type, sat_ver, rhel_ver)
-            if sat_ver >= "6.7" or sat_ver >= "67":
-                cmd = "subscription-manager register --org Sat6-CI --activationkey '%s-%s-qa-rhel%s'" % (repo_type, sat_ver, rhel_ver)
+            cmd = "subscription-manager register --org Sat6-CI --activationkey '%s-%s-qa-rhel%s'" % (repo_type, sat_ver, rhel_ver)
             ret, output = self.runcmd(cmd, ssh_sat, desc="register and enable repo")
             if ret == 0:
                 cmd = "subscription-manager attach --pool 8a88800f5ca45116015cc807610319ed"


### PR DESCRIPTION
Satellite installing failed due to the error:
```
2021-05-21 08:53:52 [ERROR] Failed to install satellite package(ent-02-vm-01.lab.eng.nay.redhat.com)
Traceback (most recent call last):
  File "/home/jenkins/workspace/Plugin-Pipeline/virtwho-ci/utils/installer.py", line 395, in <module>
    install_satellite(args)
  File "/home/jenkins/workspace/Plugin-Pipeline/virtwho-ci/utils/installer.py", line 83, in install_satellite
    provision.satellite_pkg_install(ssh_sat)
  File "/home/jenkins/workspace/Plugin-Pipeline/virtwho-ci/virt_who/provision.py", line 1392, in satellite_pkg_install
    raise FailException("Failed to install satellite package({0})".format(sat_host))
virt_who.FailException: Failed to install satellite package(ent-02-vm-01.lab.eng.nay.redhat.com)
```
```
>>> Running in: ent-02-vm-01.lab.eng.nay.redhat.com:22, Desc: register and enable repo
Command: subscription-manager register --org Sat6-CI --activationkey 'satellite-6.10.0-qa-rhel7'
Retcode: 70
Output:
HTTP error (404 - Not Found): Couldn't find activation key 'satellite-6.10.0-qa-rhel7'
```


Remove the ".0" from activationkey to fix Statellite installing error