### PR TITLE
Remove the foreman-admin-password option

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1394,10 +1394,7 @@ class Provision(Register):
             manifest_filename = "{0}/{1}".format(manifest_path, output.strip())
         else:
             raise FailException("No manifest file found")
-        if sat_ver >= "6.6":
-            options = "--disable-system-checks --foreman-initial-admin-password={0}".format(admin_passwd)
-        else:
-            options = "--disable-system-checks --foreman-admin-password={0}".format(admin_passwd)
+        options = "--disable-system-checks --foreman-initial-admin-password={0}".format(admin_passwd)
         cmd = "satellite-installer --scenario satellite {0}".format(options)
         ret, output = self.runcmd(cmd, ssh_sat)
         if ret != 0:

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1361,9 +1361,7 @@ class Provision(Register):
             ret, output = self.runcmd(cmd, ssh_sat, desc="uninstall katello-ca-consumer")
             cmd = "yum -y localinstall {0}".format(repo)
             ret, output = self.runcmd(cmd, ssh_sat, desc="install katello-ca")
-            cmd = "subscription-manager register --org Sat6-CI --activationkey '%s-%s.0-qa-rhel%s'" % (repo_type, sat_ver, rhel_ver)
-            if sat_ver >= "6.7" or sat_ver >= "67":
-                cmd = "subscription-manager register --org Sat6-CI --activationkey '%s-%s-qa-rhel%s'" % (repo_type, sat_ver, rhel_ver)
+            cmd = "subscription-manager register --org Sat6-CI --activationkey '%s-%s-qa-rhel%s'" % (repo_type, sat_ver, rhel_ver)
             ret, output = self.runcmd(cmd, ssh_sat, desc="register and enable repo")
             if ret == 0:
                 cmd = "subscription-manager attach --pool 8a88800f5ca45116015cc807610319ed"


### PR DESCRIPTION
As `"6.10"` > `"6.6"` is `False`, and we are now using the `--foreman-initial-admin-password` now, need to remove the old one to fix the error:

```
>>> Running in: ent-02-vm-06.lab.eng.nay.redhat.com:22, Desc: None
Command: satellite-installer --scenario satellite --disable-system-checks --foreman-admin-password=admin
Retcode: 1
Output:
[34m2021-05-24 09:03:35[0m [[32mNOTICE[0m] [[36mroot[0m] Loading installer configuration. This will take some time.
[34m2021-05-24 09:03:41[0m [[32mNOTICE[0m] [[36mroot[0m] Running installer with log based terminal output at level NOTICE.
[34m2021-05-24 09:03:41[0m [[32mNOTICE[0m] [[36mroot[0m] Use -l to set the terminal output log level to ERROR, WARN, NOTICE, INFO, or DEBUG. See --full-help for definitions.
ERROR: Unrecognised option '--foreman-admin-password'
```