### PR TITLE
add ansible repo to install satellite

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1343,7 +1343,8 @@ class Provision(Register):
                 --enable=rhel-{0}-server-satellite-maintenance-6-rpms \
                 --enable=rhel-{0}-server-satellite-capsule-{1}-rpms \
                 --enable=rhel-{0}-server-satellite-{1}-rpms \
-                --enable=rhel-{0}-server-satellite-tools-{1}-rpms".format(rhel_ver, sat_ver)
+                --enable=rhel-{0}-server-satellite-tools-{1}-rpms \
+                --enable=rhel-{0}-server-ansible-2.9-rpms".format(rhel_ver, sat_ver)
         status, output = self.run_loop(cmd, ssh_sat, desc="enable satellite repos")
         if status != "Yes":
             raise FailException("Failed to enable satellite repos({0})".format(sat_host))


### PR DESCRIPTION
Add ```--enable=rhel-{0}-server-ansible-2.9-rpms``` to install satellite by cdn.


```
Error: Package: satellite-common-6.9.2-1.el7sat.noarch (rhel-7-server-satellite-6.9-rpms)
           Requires: ansible >= 2.9
           Available: ansible-2.3.1.0-3.el7.noarch (rhel-7-server-extras-rpms)
               ansible = 2.3.1.0-3.el7
           Available: ansible-2.3.2.0-2.el7.noarch (rhel-7-server-extras-rpms)
               ansible = 2.3.2.0-2.el7
           Available: ansible-2.4.0.0-1.el7ae.noarch (rhel-7-server-satellite-maintenance-6-rpms)
               ansible = 2.4.0.0-1.el7ae
           Available: ansible-2.4.0.0-5.el7.noarch (rhel-7-server-extras-rpms)
               ansible = 2.4.0.0-5.el7
           Available: ansible-2.4.1.0-1.el7.noarch (rhel-7-server-extras-rpms)
               ansible = 2.4.1.0-1.el7
           Installing: ansible-2.4.2.0-2.el7.noarch (rhel-7-server-extras-rpms)
               ansible = 2.4.2.0-2.el7
```