### PR TITLE
Update tc_1004 to fix bz1951347

### DIFF
--- a/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
+++ b/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
@@ -8,6 +8,7 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-133657')
         trigger_type = self.get_config('trigger_type')
+        compose_id = self.get_config('rhel_compose')
         if "trigger-rhev" in trigger_type:
             self.vw_case_skip(trigger_type)
 
@@ -20,6 +21,8 @@ class Testcase(Testing):
         ret, output = self.runcmd("man virt-who-config", self.ssh_host())
         results.setdefault('step2', []).append("configuration for virt-who" in output)
         msg = "backend names: libvirt, esx, rhevm, hyperv, fake, xen, or kube.*\n.*virt"
+        if "RHEL-9" in compose_id:
+            msg = "backend names: libvirt, esx, rhevm, hyperv, fake, or kubevirt"
         results.setdefault('step2', []).append(self.vw_msg_search(output, msg))
 
         logger.info(">>>step3: virt-who have correct help page")


### PR DESCRIPTION
Based on bz1951347, xen has been removed from rhel9.0 Beta and the virt-who-config man page is also updated to remove xen keyword, so updated code.

```
# pytest-3 tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py 
========= test session starts =======================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /root/workspace/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.3.0, xdist-1.34.0
collected 1 item                                                                                                                                             

tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py .       [100%]

```
