### PR TITLE
Update tc_2060 due to new behavior of type

### DIFF
--- a/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
+++ b/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
@@ -36,7 +36,7 @@ class Testcase(Testing):
         ret, output = self.runcmd(cmd, self.ssh_host(), desc="add new line with tab")
         data, tty_output, rhsm_output = self.vw_start(exp_send=0)
         msg = "virt-who can't be started"
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=0, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=0, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, msg)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
@@ -44,14 +44,14 @@ class Testcase(Testing):
         logger.info(">>>step3: comment out the useless line")
         cmd = 'sed -i "s/xxx/#xxx/" {0}'.format(config_file)
         ret, output = self.runcmd(cmd, self.ssh_host())
-        if "RHEL-8" in compose_id:
-            data, tty_output, rhsm_output = self.vw_start(exp_send=1)
-            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         if "RHEL-7" in compose_id:
             war_msg = "A line continuation (line starts with space) that is commented " \
                       "out was detected in file"
             data, tty_output, rhsm_output = self.vw_start(exp_send=0)
             res1 = self.op_normal_value(data, exp_error=1, exp_thread=0, exp_send=0)
+        else:
+            data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step3', []).append(res1)
 
         # Case Result


### PR DESCRIPTION
When run virt-who in rhel9.0 Beta with wrong type value, will print the other error "Unsupported virtual type 'esx
xxx=xxx' is set", so update the ```exp_error="1|2"```

```
# pytest-3 tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py 
================== test session starts =================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /root/workspace/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.3.0, xdist-1.34.0
collected 1 item                                                                                                                                             

tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py .   [100%]

======================= 1 passed==========
```