### PR TITLE
Update tc_2052 to be compatible with cnv2.x

### DIFF
--- a/tests/tier2/tc_2052_validate_hypervisors_connection.py
+++ b/tests/tier2/tc_2052_validate_hypervisors_connection.py
@@ -81,10 +81,7 @@ class Testcase(Testing):
 
         # case result
         if 'kubevirt' in hypervisor_type:
-            notes = list()
-            notes.append("Bug(Step2): No any response after kubevirt lost its connection with virt-who host")
-            notes.append("BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1712300")
-            self.vw_case_result(results, notes)
+            self.vw_case_result(results)
         else:
             self.vw_case_result(results)
 

--- a/tests/tier2/tc_2052_validate_hypervisors_connection.py
+++ b/tests/tier2/tc_2052_validate_hypervisors_connection.py
@@ -80,8 +80,5 @@ class Testcase(Testing):
                 results.setdefault('step3', []).append(False)
 
         # case result
-        if 'kubevirt' in hypervisor_type:
-            self.vw_case_result(results)
-        else:
-            self.vw_case_result(results)
+        self.vw_case_result(results)
 

--- a/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
+++ b/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
@@ -36,7 +36,7 @@ class Testcase(Testing):
         ret, output = self.runcmd(cmd, self.ssh_host(), desc="add new line with tab")
         data, tty_output, rhsm_output = self.vw_start(exp_send=0)
         msg = "virt-who can't be started"
-        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=0, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error=1, exp_thread=0, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, msg)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
@@ -44,14 +44,14 @@ class Testcase(Testing):
         logger.info(">>>step3: comment out the useless line")
         cmd = 'sed -i "s/xxx/#xxx/" {0}'.format(config_file)
         ret, output = self.runcmd(cmd, self.ssh_host())
+        if "RHEL-8" in compose_id:
+            data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         if "RHEL-7" in compose_id:
             war_msg = "A line continuation (line starts with space) that is commented " \
                       "out was detected in file"
             data, tty_output, rhsm_output = self.vw_start(exp_send=0)
             res1 = self.op_normal_value(data, exp_error=1, exp_thread=0, exp_send=0)
-        else:
-            data, tty_output, rhsm_output = self.vw_start(exp_send=1)
-            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step3', []).append(res1)
 
         # Case Result

--- a/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
+++ b/tests/tier2/tc_2060_check_commented_out_line_with_tab_space.py
@@ -36,7 +36,7 @@ class Testcase(Testing):
         ret, output = self.runcmd(cmd, self.ssh_host(), desc="add new line with tab")
         data, tty_output, rhsm_output = self.vw_start(exp_send=0)
         msg = "virt-who can't be started"
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=0, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=0, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, msg)
         results.setdefault('step2', []).append(res1)
         results.setdefault('step2', []).append(res2)
@@ -44,14 +44,14 @@ class Testcase(Testing):
         logger.info(">>>step3: comment out the useless line")
         cmd = 'sed -i "s/xxx/#xxx/" {0}'.format(config_file)
         ret, output = self.runcmd(cmd, self.ssh_host())
-        if "RHEL-8" in compose_id:
-            data, tty_output, rhsm_output = self.vw_start(exp_send=1)
-            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         if "RHEL-7" in compose_id:
             war_msg = "A line continuation (line starts with space) that is commented " \
                       "out was detected in file"
             data, tty_output, rhsm_output = self.vw_start(exp_send=0)
             res1 = self.op_normal_value(data, exp_error=1, exp_thread=0, exp_send=0)
+        else:
+            data, tty_output, rhsm_output = self.vw_start(exp_send=1)
+            res1 = self.op_normal_value(data, exp_error=0, exp_thread=1, exp_send=1)
         results.setdefault('step3', []).append(res1)
 
         # Case Result

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -402,7 +402,6 @@ class Testing(Provision):
             host = var[0]
         if hypervisor_type == "rhevm" \
                 or hypervisor_type == "libvirt-remote" \
-                or hypervisor_type == "kubevirt" \
                 or hypervisor_type == "xen":
             if action == "off":
                 cmd = "iptables -I INPUT -s {0} -j DROP".format(host)
@@ -418,6 +417,13 @@ class Testing(Provision):
                 cmd2 = "NetSh Advfirewall set allprofiles state off"
             ret, output = self.runcmd(cmd1, ssh_hypervisor)
             ret, output = self.runcmd(cmd2, ssh_hypervisor)
+        if hypervisor_type == "kubevirt":
+            kubevirt_host = ssh_hypervisor['host']
+            if action == "off":
+                cmd = "iptables -I INPUT -s {0} -j DROP".format(kubevirt_host)
+            if action == "on":
+                cmd = "iptables -D INPUT -s {0} -j DROP".format(kubevirt_host)
+            ret, output = self.runcmd(cmd, ssh_host)
 
     #******************************************
     # virt-who config function


### PR DESCRIPTION
- The old code was designed when ocp3, but for ocp4+cnv2, the code was not supported to ssh log in the openshift cluster to handle firewall by command, which need quicklab.key in our environment, will add this function in our new virtwho-test project.

- But for the current virtwho-ci project, just use a workaround, that is run command ``` iptables -I INPUT -s [cluster-host] -j DROP``` on the virt-who host to handle the firewall. 

- About why use this workaround is because I didn't find a method to disconnect the virt-who host with ocp on the cluster side after tried some ways by reading document, like design yaml file about ```NetworkPolicy``` and ```EgressNetworkPolicy```, which only for the disconnection for internal pods.

- And I think it's a better and easy way to just handle firewall in virt-who host to avoid edit hypervisor environments, which need to discuss with team.

```
>>> Running in: api.virtwhotest.lab.pnq2.cee.redhat.com:22, Desc: None
Command: iptables -I INPUT -s 10.73.131.245 -j DROP
Retcode: -1
Output:
('Bad authentication type', ['publickey', 'gssapi-keyex', 'gssapi-with-mic']) (allowed_types=['publickey', 'gssapi-keyex', 'gssapi-with-mic'])
```