### PR TITLE
Change graphics_type to vnc when install libvirt guests for rhel9

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2590,6 +2590,9 @@ class Provision(Register):
             guest_mac = self.randomMAC()
             cmd = "sed -i -e 's|<mac address=.*/>|<mac address=\"{0}\"/>|g' {1}".format(guest_mac, guest_xml)
             self.runcmd(cmd, ssh_libvirt, desc="libvirt xml mac address update")
+            if self.rhel_version(ssh_libvirt) == "9":
+                cmd = "sed -i -e 's|<graphics type=.* |<graphics type=\"vnc\" |g' {0}".format(guest_xml)
+                self.runcmd(cmd, ssh_libvirt, desc="libvirt graphics type update")
         cmd = "virsh define {0}".format(guest_xml)
         ret, output = self.runcmd(cmd, ssh_libvirt, desc="libvirt define guest")
         logger.info("Succeeded to download libvirt image to {0}".format(ssh_libvirt['host']))


### PR DESCRIPTION
Based on https://bugzilla.redhat.com/show_bug.cgi?id=1946939, in rhel-9 the virt-manager will not use spice as graphics any more, which should be replaced by vnc, so updated the code to support deploying local libvirt mode.