### PR TITLE
Remove installing python3-pexpect for rhel9.0 docker image

### DIFF
--- a/docker/mk_image.sh
+++ b/docker/mk_image.sh
@@ -117,13 +117,17 @@ do
     yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs --setopt=group_package_types=mandatory \
         -y install @base openssh-server openssh-clients openssl-devel net-tools wget hostname sudo subscription-manager gcc expect
     # different packages for rhel8/9 and rhel7
-    if [[ $name =~ "rhel7" ]] || [[ $name =~ "rhel-7" ]] || [[ $name =~ "rhel.7" ]]
+    if [[ $name =~ "rhel7" ]] || [[ $name =~ "rhel-7" ]] || [[ $name =~ "rhel.7" ]];
     then
         yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs --setopt=group_package_types=mandatory \
             -y install @x11 subscription-manager-gui pexpect libvirt-python python-devel
-    else
+    elif [[ $name =~ "rhel8" ]] || [[ $name =~ "rhel-8" ]] || [[ $name =~ "rhel.8" ]];
+    then
         yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs --setopt=group_package_types=mandatory \
             -y install cockpit subscription-manager-cockpit python3-pexpect python3-libvirt glibc-all-langpacks
+    else
+        yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs --setopt=group_package_types=mandatory \
+            -y install cockpit subscription-manager-cockpit python3-libvirt glibc-all-langpacks
     fi
     # try again if failed to install
     if [ $? -eq 0 ]


### PR DESCRIPTION
python3-pexpect is being dropped in RHEL 9 and will not be shipped in bz1979103.

```
# nosetests-3 /root/workspace/virtwho-ci/tests/tier3/tc_debug.py
2021-07-19 11:03:01 [INFO] docker image rhel-9.0.0-20210717.1 is not exist(10.73.131.245)
2021-07-19 11:03:01 [INFO] Start to create docker image rhel-9.0.0-20210717.1
2021-07-19 11:03:02 [INFO] Command to create docker image: sh /tmp/docker/mk_image.sh -y /tmp/docker/compose.repo rhel-9.0.0-20210717.1
2021-07-19 11:12:42 [INFO] Succeeded to create compose image rhel-9.0.0-20210717.1

```