### PR TITLE
update tc_1004 to fix failure due to man page changes

### DIFF
--- a/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
+++ b/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
@@ -14,8 +14,11 @@ class Testcase(Testing):
 
         results = dict()
         logger.info(">>>step1: virt-who have correct man page")
+        msg = "Agent for reporting virtual guest IDs to Subscription"
+        if "RHEL-9" in compose_id:
+            msg = "Agent  for  reporting  virtual guest IDs to an entitlement.*\n.*server"
         ret, output = self.runcmd("man virt-who", self.ssh_host(), desc="run man virt-who")
-        results.setdefault('step1', []).append("Agent for reporting virtual guest IDs to Subscription" in output)
+        results.setdefault('step1', []).append(self.vw_msg_search(output, msg))
 
         logger.info(">>>step2: virt-who-config have correct man page")
         ret, output = self.runcmd("man virt-who-config", self.ssh_host())


### PR DESCRIPTION
The virt-who man page of rhel9.0 beta changed to "virt-who  -  Agent  for  reporting  virtual guest IDs to an entitlement server" from "Agent for reporting virtual guest IDs to Subscription".