### PR TITLE
Add vw_status function

### DIFF
--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -1460,5 +1460,4 @@ class Testing(Provision):
                     status_data[name]['source'] = item['source']
                 if 'destination' in item.keys():
                     status_data[name]['destination'] = item['destination']
-        logger.info(status_data)
         return status_data

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -1431,3 +1431,34 @@ class Testing(Provision):
                 logger.info("virtwho loop time(%s) is expected" % loop_time)
         logger.info("Finished to validate all the expected options")
         return True
+
+    def vw_status(self, cmd='virt-who --status', if_json=False):
+        status_data = dict()
+        if if_json != False:
+            cmd += ' --json'
+        ret, output = self.runcmd(cmd, self.ssh_host())
+        if not if_json and 'Configuration Name' in output:
+            status = output.strip().split('\n')
+            for item in status:
+                num = status.index(item)
+                if 'Configuration Name' in item:
+                    config_name = item.split(':')[1].strip()
+                    status_data[config_name] = dict()
+                    if 'Source Status:' in status[num+1]:
+                        status_data[config_name]['source_status'] = \
+                            status[num+1].split(':')[1].strip()
+                    if 'Destination Status:' in status[num+2]:
+                        status_data[config_name]['destination_status'] = \
+                            status[num+2].split(':')[1].strip()
+        if if_json and 'configurations' in output:
+            output = json.loads(output.replace('\n', ''), strict=False)
+            configurations = output['configurations']
+            for item in configurations:
+                name = item['name']
+                status_data[name] = dict()
+                if 'source' in item.keys():
+                    status_data[name]['source'] = item['source']
+                if 'destination' in item.keys():
+                    status_data[name]['destination'] = item['destination']
+        logger.info(status_data)
+        return status_data


### PR DESCRIPTION
Add vw_status function to run virt-who status and analyse the output.

- The analysis result for #virt-who --status

```
{'virtwho-config': {'source_status': '\x1b[1;32msuccess\x1b[0;0m', 'destination_status': '\x1b[1;32msuccess\x1b[0;0m'}, 'rhevm': {'source_status': '\x1b[1;32msuccess\x1b[0;0m', 'destination_status': '\x1b[1;32msuccess\x1b[0;0m'}}
```

- The analysis result for #virt-who --status --json

```
{'rhevm': {'source': {'connection': 'https://bootp-73-130-xxx.rhts.eng.pek2.redhat.com:443/', 'status': 'success', 'last_successful_retrieve': '2021-08-05 09:11:27 UTC', 'hypervisors': 1, 'guests': 1}, 'destination': {'connection': 'ent-02-vm-xx.lab.eng.nay.redhat.com', 'status': 'success', 'last_successful_send': '2021-08-05 09:11:29 UTC', 'last_successful_send_job_status': 'FINISHED'}}, 'virtwho-config': {'source': {'connection': 'https://10.73.130.xx', 'status': 'success', 'last_successful_retrieve': '2021-08-05 09:11:26 UTC', 'hypervisors': 1, 'guests': 1}, 'destination': {'connection': 'ent-02-vm-xx.lab.eng.nay.redhat.com', 'status': 'success', 'last_successful_send': '2021-08-05 09:11:29 UTC', 'last_successful_send_job_status': 'FINISHED'}}}

```