### PR TITLE
Fix issue of subscription-manager disabled in rhel container

### DIFF
--- a/docker/mk_container.sh
+++ b/docker/mk_container.sh
@@ -77,6 +77,7 @@ fi
 docker exec -i $container_name sed -i 's/#UseDNS yes/UseDNS no/g' /etc/ssh/sshd_config
 docker exec -i $container_name sed -i 's/GSSAPIAuthentication yes/GSSAPIAuthentication no/g' /etc/ssh/sshd_config
 docker exec -i $container_name sed -i 's/#X11UseLocalhost yes/X11UseLocalhost no/g' /etc/ssh/sshd_config
+docker exec -i $container_name rm -rf /.dockerenv
 echo -e "" | docker exec -i $container_name ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key > /dev/null 2>&1
 echo -e "" | docker exec -i $container_name ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key > /dev/null 2>&1
 docker exec -i $container_name /usr/sbin/sshd


### PR DESCRIPTION
Remove the /.dockerenv file from container, which is to mark it's a docker environment. subscription-manager is disabled when running inside a container, so we have to remove the file.