### PR TITLE
Support nutanix/ahv mode

### DIFF
--- a/virt_who/settings.py
+++ b/virt_who/settings.py
@@ -565,6 +565,32 @@ class SetKubevirt(FeatureSettings):
         self.kube_config_url = reader.get('kubevirt', 'kube_config_url')
         self.kube_config_url_no_cert = reader.get('kubevirt', 'kube_config_url_no_cert')
 
+class SetAhv(FeatureSettings):
+    def __init__(self, *args, **kwargs):
+        super(SetAhv, self).__init__(*args, **kwargs)
+        self.master = None
+        self.master_user = None
+        self.master_passwd = None
+        self.guest_name = None
+        self.guest_user = None
+        self.guest_passwd = None
+        self.host_name = None
+        self.host_uuid = None
+        self.guest_ip = None
+        self.guest_uuid = None
+
+    def read(self, reader):
+        self.master = reader.get('ahv', 'master')
+        self.master_user = reader.get('ahv', 'master_user')
+        self.master_passwd = reader.get('ahv', 'master_passwd')
+        self.guest_name = reader.get('ahv', 'guest_name')
+        self.guest_user = reader.get('ahv', 'guest_user')
+        self.guest_passwd = reader.get('ahv', 'guest_passwd')
+        self.host_name = reader.get('ahv', 'host_name')
+        self.host_uuid = reader.get('ahv', 'host_uuid')
+        self.guest_ip = reader.get('ahv', 'guest_ip')
+        self.guest_uuid = reader.get('ahv', 'guest_uuid')
+
 class DeploySettings(Settings):
     def __init__(self):
         self.trigger = SetTrigger()
@@ -585,6 +611,7 @@ class DeploySettings(Settings):
         self.vdsm = SetVDSM()
         self.libvirt = SetLibvirt()
         self.kubevirt = SetKubevirt()
+        self.ahv = SetAhv()
 
 class ConfigureVirtwho(FeatureSettings):
     def __init__(self, *args, **kwargs):

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -214,6 +214,8 @@ class Testing(Provision):
             hostname = self.get_hostname(ssh_hypervisor)
         if hypervisor_type == "kubevirt":
             hostname = self.kubevirt_guest_attrs(guest_name)['guest_node']
+        if hypervisor_type == "ahv":
+            hostname = self.ahv_host_name()
         if hypervisor_type == "rhevm":
             rhevm_shell, rhevm_shellrc = self.rhevm_shell_get(ssh_hypervisor)
             hostname = self.rhevm_host_name_by_guestname(ssh_hypervisor, rhevm_shell, guest_name)
@@ -242,6 +244,8 @@ class Testing(Provision):
         if hypervisor_type == "kubevirt":
             node_name = self.kubevirt_guest_attrs(guest_name)['guest_node']
             uuid = self.kubevirt_host_attrs(node_name)['host_uuid']
+        if hypervisor_type == "ahv":
+            uuid = self.ahv_host_uuid()
         if hypervisor_type == "libvirt-local":
             uuid = self.libvirt_host_uuid(self.ssh_host())
         if hypervisor_type == "libvirt-remote":
@@ -283,6 +287,8 @@ class Testing(Provision):
             uuid = self.xen_guest_uuid(ssh_hypervisor, guest_name)
         if hypervisor_type == "kubevirt":
             uuid = self.kubevirt_guest_attrs(guest_name)['guest_id']
+        if hypervisor_type == "ahv":
+            uuid = self.ahv_guest_uuid()
         if hypervisor_type == "libvirt-local":
             uuid = self.libvirt_guest_uuid(guest_name, self.ssh_host())
         if hypervisor_type == "libvirt-remote":


### PR DESCRIPTION
- The nutanix is formally supported by virt-who, so it's necessary to update code to support the new mode.

- But because the time is limited and env no stable to learn and develop the api of nutainix, so we should provide the guest_ip/uuid, host_uuid/name by manual.

- And some cases are not supported by auto, like the guest start/stop...

```
    #*********************************************
    # Hypervisor Nutanix Function
    #*********************************************

    def ahv_guest_ip(self):
        return deploy.ahv.guest_ip

    def ahv_guest_uuid(self):
        return deploy.ahv.guest_uuid

    def ahv_host_uuid(self):
        return deploy.ahv.host_uuid

    def ahv_host_name(self):
        return deploy.ahv.host_name
```