### PR TITLE
Update tc_1004 for ahv mode

### DIFF
--- a/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
+++ b/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
@@ -23,9 +23,9 @@ class Testcase(Testing):
         logger.info(">>>step2: virt-who-config have correct man page")
         ret, output = self.runcmd("man virt-who-config", self.ssh_host())
         results.setdefault('step2', []).append("configuration for virt-who" in output)
-        msg = "backend names: libvirt, esx, rhevm, hyperv, fake, xen, or kube.*\n.*virt"
+        msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, xen, or.*\n.*kubevirt"
         if "RHEL-9" in compose_id:
-            msg = "backend names: libvirt, esx, rhevm, hyperv, fake, or kubevirt"
+            msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, or kube.*\n.*virt."
         results.setdefault('step2', []).append(self.vw_msg_search(output, msg))
 
         logger.info(">>>step3: virt-who have correct help page")


### PR DESCRIPTION
The man page is changed to add ahv mode introduction, so update the case to cover the new behavior.

```
# pytest-3 tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py 
============================ test session starts ============================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /root/workspace/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.3.0, xdist-1.34.0
collected 1 item                                                                                                                                             

tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py .                                                                           [100%]

===================== 1 passed, 9 warnings in 4.36s =====================
```