### PR TITLE
Update tc_1108 to support ahv

### DIFF
--- a/tests/tier1/tc_1108_check_hypervisor_facts.py
+++ b/tests/tier1/tc_1108_check_hypervisor_facts.py
@@ -31,11 +31,6 @@ class Testcase(Testing):
         facts_items = ['socket', 'type', 'dmi', 'version']
         if hypervisor_type in ('esx', 'rhevm', 'ahv'):
             facts_items.append('cluster')
-            cluster_values = {
-                'esx': deploy.vcenter.cluster,
-                'rhevm': deploy.rhevm.cluster,
-                'ahv': deploy.ahv.cluster
-            }
         type_values = {
             'kubevirt': 'qemu',
             'xen': 'XenServer',
@@ -44,6 +39,11 @@ class Testcase(Testing):
             'libvirt-remote': 'QEMU',
             'rhevm': 'qemu',
             'ahv': 'ahv'
+        }
+        cluster_values = {
+            'esx': deploy.vcenter.cluster,
+            'rhevm': deploy.rhevm.cluster,
+            'ahv': deploy.ahv.cluster
         }
 
         # Case Steps

--- a/tests/tier1/tc_1108_check_hypervisor_facts.py
+++ b/tests/tier1/tc_1108_check_hypervisor_facts.py
@@ -28,21 +28,22 @@ class Testcase(Testing):
         register_config = self.get_register_config()
         register_owner = register_config['owner']
         host_uuid = self.get_hypervisor_hostuuid()
-        if hypervisor_type in ('esx', 'rhevm'):
-            facts_items = ('socket', 'type', 'dmi', 'version', 'cluster')
-        else:
-            facts_items = ('socket', 'type', 'dmi', 'version')
+        facts_items = ['socket', 'type', 'dmi', 'version']
+        if hypervisor_type in ('esx', 'rhevm', 'ahv'):
+            facts_items.append('cluster')
+            cluster_values = {
+                'esx': deploy.vcenter.cluster,
+                'rhevm': deploy.rhevm.cluster,
+                'ahv': deploy.ahv.cluster
+            }
         type_values = {
             'kubevirt': 'qemu',
             'xen': 'XenServer',
             'hyperv': 'hyperv',
             'esx': 'VMware ESXi',
             'libvirt-remote': 'QEMU',
-            'rhevm': 'qemu'
-        }
-        cluster_values = {
-            'esx': 'virtwho-test',
-            'rhevm': 'Default'
+            'rhevm': 'qemu',
+            'ahv': 'ahv'
         }
 
         # Case Steps
@@ -89,7 +90,7 @@ class Testcase(Testing):
             logger.error("dmi.system.uuid is not {0}".format(host_uuid))
             results.setdefault('step4', []).append(False)
 
-        if hypervisor_type in ('esx', 'rhevm'):
+        if hypervisor_type in ('esx', 'rhevm', 'ahv'):
             logger.info(">>>step5: check hypervisor.cluster value")
             cluster_value = cluster_values[hypervisor_type]
             if facts_dic['cluster'] == cluster_value:

--- a/virt_who/settings.py
+++ b/virt_who/settings.py
@@ -348,6 +348,7 @@ class SetVcenter(FeatureSettings):
         self.master = None
         self.master_user = None
         self.master_passwd = None
+        self.cluster = None
         self.slave = None
         self.slave_user = None
         self.slave_passwd = None
@@ -365,6 +366,7 @@ class SetVcenter(FeatureSettings):
         self.master = reader.get('vcenter', 'master')
         self.master_user = reader.get('vcenter', 'master_user')
         self.master_passwd = reader.get('vcenter', 'master_passwd')
+        self.cluster = reader.get('vcenter', 'cluster')
         self.slave = reader.get('vcenter', 'slave')
         self.slave_user = reader.get('vcenter', 'slave_user')
         self.slave_passwd = reader.get('vcenter', 'slave_passwd')
@@ -577,6 +579,7 @@ class SetAhv(FeatureSettings):
         self.master = None
         self.master_user = None
         self.master_passwd = None
+        self.cluster = None
         self.guest_name = None
         self.guest_user = None
         self.guest_passwd = None
@@ -589,6 +592,7 @@ class SetAhv(FeatureSettings):
         self.master = reader.get('ahv', 'master')
         self.master_user = reader.get('ahv', 'master_user')
         self.master_passwd = reader.get('ahv', 'master_passwd')
+        self.cluster = reader.get('ahv', 'cluster')
         self.guest_name = reader.get('ahv', 'guest_name')
         self.guest_user = reader.get('ahv', 'guest_user')
         self.guest_passwd = reader.get('ahv', 'guest_passwd')


### PR DESCRIPTION
Virt-who also gets the hypervisor.cluster from nutanix, so updated the case to support ahv mode.
And changed to define the cluster= value from configuration file, not in case, which will be more convenient to maintain.
```
# pytest-3 tests/tier1/tc_1108_check_hypervisor_facts.py 
====================== test session starts ======================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /root/workspace/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.3.0, xdist-1.34.0
collected 1 item                                                                                                                                             

tests/tier1/tc_1108_check_hypervisor_facts.py .                                                                                                        [100%]

================= 1 passed, 9 warnings in 216.06s (0:03:36) =============
```