### PR TITLE
Maintain libvirt_guest_stop()

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2771,7 +2771,7 @@ class Provision(Register):
     def libvirt_guest_stop(self, guest_name, ssh_libvirt):
         host = ssh_libvirt['host']
         cmd = "virsh shutdown {0}".format(guest_name)
-        ret, output = self.runcmd(cmd, ssh_libvirt, desc="virsh destroy")
+        ret, output = self.runcmd(cmd, ssh_libvirt, desc="virsh shutdown")
         for i in range(10):
             if self.libvirt_guest_status(guest_name, ssh_libvirt) == "shut off":
                 logger.info("Succeeded to shutdown libvirt({0}) guest".format(host))

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2770,7 +2770,7 @@ class Provision(Register):
 
     def libvirt_guest_stop(self, guest_name, ssh_libvirt):
         host = ssh_libvirt['host']
-        cmd = "virsh destroy {0}".format(guest_name)
+        cmd = "virsh shutdown {0}".format(guest_name)
         ret, output = self.runcmd(cmd, ssh_libvirt, desc="virsh destroy")
         for i in range(10):
             if self.libvirt_guest_status(guest_name, ssh_libvirt) == "shut off":


### PR DESCRIPTION
Because the tc_2053 case often fails due to after ```#virsh shutoff [guest name]```  the guest state shows ```error: failed to get domain '8.0_Server_x86_64'```.
Change the ```#virsh shutoff [guest name]``` to ```#virsh shutdown [guest name]```.

```
# pytest-3 tests/tier2/tc_2053_validate_guest_state_when_suspend_resume_stop_start.py
========================== test session starts ==========================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /root/workspace/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.3.0, xdist-1.34.0
collected 1 item                                                                                                                                             

tests/tier2/tc_2053_validate_guest_state_when_suspend_resume_stop_start.py .                                                                           [100%]
======================= 1 passed, 9 warnings in 586.17s (0:09:46) ======================
```