### PR TITLE
Update tc_2022/2023/2025/2026 because of error number changing

### DIFF
--- a/tests/tier2/tc_2022_validate_rhsm_hostname_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2022_validate_rhsm_hostname_option_in_etc_virtwho_d.py
@@ -9,6 +9,7 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136627')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         self.vw_case_init()
@@ -45,7 +46,10 @@ class Testcase(Testing):
             logger.info(">>>step2: run virt-who with rhsm_hostname=xxxxxx")
             self.vw_option_update_value("rhsm_hostname", "xxxxxx", config_file)
             data, tty_output, rhsm_output = self.vw_start()
-            res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
+            error_num = 1
+            if 'RHEL-9' in compose_id:
+                error_num = 2
+            res1 = self.op_normal_value(data, exp_error=error_num, exp_thread=1, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, "Name or service not known")
             results.setdefault('step2', []).append(res1)
             results.setdefault('step2', []).append(res2)

--- a/tests/tier2/tc_2022_validate_rhsm_hostname_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2022_validate_rhsm_hostname_option_in_etc_virtwho_d.py
@@ -45,7 +45,7 @@ class Testcase(Testing):
             logger.info(">>>step2: run virt-who with rhsm_hostname=xxxxxx")
             self.vw_option_update_value("rhsm_hostname", "xxxxxx", config_file)
             data, tty_output, rhsm_output = self.vw_start()
-            res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+            res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, "Name or service not known")
             results.setdefault('step2', []).append(res1)
             results.setdefault('step2', []).append(res2)

--- a/tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py
@@ -8,6 +8,7 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136628')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         self.vw_case_init()
@@ -43,7 +44,10 @@ class Testcase(Testing):
             logger.info(">>>step2: run virt-who with rhsm_port=123")
             self.vw_option_update_value("rhsm_port", "123", config_file)
             data, tty_output, rhsm_output = self.vw_start()
-            res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
+            error_num = 1
+            if 'RHEL-9' in compose_id:
+                error_num = 2
+            res1 = self.op_normal_value(data, exp_error=error_num, exp_thread=1, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, "Connection refused", exp_exist=True)
             results.setdefault('step2', []).append(res1)
             results.setdefault('step2', []).append(res2)

--- a/tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py
@@ -43,7 +43,7 @@ class Testcase(Testing):
             logger.info(">>>step2: run virt-who with rhsm_port=123")
             self.vw_option_update_value("rhsm_port", "123", config_file)
             data, tty_output, rhsm_output = self.vw_start()
-            res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+            res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
             res2 = self.vw_msg_search(rhsm_output, "Connection refused", exp_exist=True)
             results.setdefault('step2', []).append(res1)
             results.setdefault('step2', []).append(res2)

--- a/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
@@ -78,7 +78,7 @@ class Testcase(Testing):
         error_msg = "system is not registered or you are not root"
         self.vw_option_update_value("rhsm_username", " ", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
@@ -86,7 +86,7 @@ class Testcase(Testing):
         logger.info(">>>step5: run virt-who with rhsm_username disable")
         self.vw_option_disable("rhsm_username", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)

--- a/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py
@@ -9,6 +9,7 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136630')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         self.vw_case_init()
@@ -55,7 +56,6 @@ class Testcase(Testing):
                     "Communication with subscription manager failed"]
         self.vw_option_update_value("rhsm_username", "红帽©¥®ðπ∉", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        compose_id = self.get_config('rhel_compose')
         if "RHEL-7" in compose_id:
             pkg = self.pkg_check(self.ssh_host(), 'python-requests').split('-')[2]
             if pkg[16:21] >= '2.20':
@@ -78,7 +78,10 @@ class Testcase(Testing):
         error_msg = "system is not registered or you are not root"
         self.vw_option_update_value("rhsm_username", " ", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
+        error_num = 1
+        if 'RHEL-9' in compose_id:
+            error_num = 2
+        res1 = self.op_normal_value(data, exp_error=error_num, exp_thread=1, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
@@ -86,7 +89,7 @@ class Testcase(Testing):
         logger.info(">>>step5: run virt-who with rhsm_username disable")
         self.vw_option_disable("rhsm_username", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error=error_num, exp_thread=1, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)

--- a/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
@@ -9,6 +9,7 @@ class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-136631')
         hypervisor_type = self.get_config('hypervisor_type')
+        compose_id = self.get_config('rhel_compose')
         if hypervisor_type in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)
         self.vw_case_init()
@@ -53,7 +54,6 @@ class Testcase(Testing):
         '''红帽©¥®ðπ∉ password is supported by candlepin'''
         self.vw_option_update_value("rhsm_password", "红帽©¥®ðπ∉", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        compose_id = self.get_config('rhel_compose')
         if "RHEL-7" in compose_id:
             msg = "not in latin1 encoding"
             res1 = self.op_normal_value(data, exp_error="1|2", exp_thread=0, exp_send=0)
@@ -70,7 +70,10 @@ class Testcase(Testing):
         error_msg = "system is not registered or you are not root"
         self.vw_option_update_value("rhsm_password", " ", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
+        error_num = 1
+        if 'RHEL-9' in compose_id:
+            error_num = 2
+        res1 = self.op_normal_value(data, exp_error=error_num, exp_thread=1, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
@@ -78,7 +81,7 @@ class Testcase(Testing):
         logger.info(">>>step5: run virt-who with rhsm_password disable")
         self.vw_option_disable("rhsm_password", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error=error_num, exp_thread=1, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)

--- a/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py
@@ -70,7 +70,7 @@ class Testcase(Testing):
         error_msg = "system is not registered or you are not root"
         self.vw_option_update_value("rhsm_password", " ", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step4', []).append(res1)
         results.setdefault('step4', []).append(res2)
@@ -78,7 +78,7 @@ class Testcase(Testing):
         logger.info(">>>step5: run virt-who with rhsm_password disable")
         self.vw_option_disable("rhsm_password", config_file)
         data, tty_output, rhsm_output = self.vw_start()
-        res1 = self.op_normal_value(data, exp_error=1, exp_thread=1, exp_send=0)
+        res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
         res2 = self.vw_msg_search(rhsm_output, error_msg)
         results.setdefault('step5', []).append(res1)
         results.setdefault('step5', []).append(res2)


### PR DESCRIPTION
The error numbers change to 2 in rhel9.0 when configure bad rhsm_hostname/port/username/password.

```
# pytest-3 tests/tier2/tc_2022_validate_rhsm_hostname_option_in_etc_virtwho_d.py tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py 
============================ test session starts ===========================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /root/workspace/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.3.0, xdist-1.34.0
collected 4 items                                                                                                                                            

tests/tier2/tc_2022_validate_rhsm_hostname_option_in_etc_virtwho_d.py .                                                                                [ 25%]
tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py .                                                                                    [ 50%]
tests/tier2/tc_2025_validate_rhsm_username_option_in_etc_virtwho_d.py .                                                                                [ 75%]
tests/tier2/tc_2026_validate_rhsm_password_option_in_etc_virtwho_d.py .                                                                                [100%]

======================= 4 passed, 30 warnings in 1625.30s (0:27:05) =======================
```