### PR TITLE
Update hypervisor_firewall_setup() to support ahv in tc_2052

### DIFF
--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -424,12 +424,12 @@ class Testing(Provision):
                 cmd2 = "NetSh Advfirewall set allprofiles state off"
             ret, output = self.runcmd(cmd1, ssh_hypervisor)
             ret, output = self.runcmd(cmd2, ssh_hypervisor)
-        if hypervisor_type == "kubevirt":
-            kubevirt_host = ssh_hypervisor['host']
+        if hypervisor_type == "kubevirt" or hypervisor_type == "ahv":
+            hypervisor_host = ssh_hypervisor['host']
             if action == "off":
-                cmd = "iptables -I INPUT -s {0} -j DROP".format(kubevirt_host)
+                cmd = "iptables -I INPUT -s {0} -j DROP".format(hypervisor_host)
             if action == "on":
-                cmd = "iptables -D INPUT -s {0} -j DROP".format(kubevirt_host)
+                cmd = "iptables -D INPUT -s {0} -j DROP".format(hypervisor_host)
             ret, output = self.runcmd(cmd, ssh_host)
 
     #******************************************


### PR DESCRIPTION
Update hypervisor_firewall_setup() to support ahv in tc_2052.

```
# pytest-3 tests/tier2/tc_2052_validate_hypervisors_connection.py 
================================== test session starts ==================================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /root/workspace/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.3.0, xdist-1.34.0
collected 1 item                                                                                                                                             

tests/tier2/tc_2052_validate_hypervisors_connection.py .                                                                                               [100%]

====================== 1 passed, 9 warnings in 321.95s (0:05:21) =======================
```