### PR TITLE
Fix the error about tc_1076 for xen and hyperv mode

### DIFF
--- a/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
+++ b/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
@@ -38,7 +38,7 @@ class Testcase(Testing):
         ret, output = self.runcmd(cmd, self.ssh_guest())
         logger.info(output)
         virt_host_type = output.split(':')[1].strip()
-        results.setdefault('step2', []).append(virt_type[hypervisor_type.lower()] == virt_host_type)
+        results.setdefault('step2', []).append(virt_type[hypervisor_type.lower()] in virt_host_type)
 
         logger.info(">>>step3: check virt.is_guest fact by subscription-manager in guest")
         cmd = "subscription-manager facts --list | grep virt.is_guest"


### PR DESCRIPTION
**Description**
The case about the PR(https://github.com/VirtwhoQE/virtwho-ci/pull/174) will be failed as for some modes, it will be different like xen:
```
Command: subscription-manager facts --list | grep virt.host_type
Retcode: 0
Output:
virt.host_type: hyperv, xen, xen-domU
```

use the `in` instead of `=` can fix this issue.


