### PR TITLE
Support vCenter7.0

### DIFF
--- a/virt_who/settings.py
+++ b/virt_who/settings.py
@@ -343,6 +343,7 @@ class SetVcenter(FeatureSettings):
         self.ip = None
         self.admin_user = None
         self.admin_passwd = None
+        self.ssh_ip = None
         self.ssh_user = None
         self.ssh_passwd = None
         self.master = None
@@ -361,7 +362,8 @@ class SetVcenter(FeatureSettings):
         self.ip = reader.get('vcenter', 'ip')
         self.admin_user = reader.get('vcenter', 'admin_user')
         self.admin_passwd = reader.get('vcenter', 'admin_passwd') 
-        self.ssh_user = reader.get('vcenter', 'ssh_user') 
+        self.ssh_ip = reader.get('vcenter', 'ssh_ip')
+        self.ssh_user = reader.get('vcenter', 'ssh_user')
         self.ssh_passwd = reader.get('vcenter', 'ssh_passwd')
         self.master = reader.get('vcenter', 'master')
         self.master_user = reader.get('vcenter', 'master_user')
@@ -646,6 +648,7 @@ class ConfigureHypervisor(FeatureSettings):
         self.server = None
         self.server_username = None
         self.server_password = None
+        self.server_ssh_ip = None
         self.server_ssh_user = None
         self.server_ssh_passwd = None
         self.server_config = None
@@ -659,6 +662,7 @@ class ConfigureHypervisor(FeatureSettings):
         self.server = reader.get('hypervisor', 'server')
         self.server_username = reader.get('hypervisor', 'server_username')
         self.server_password = reader.get('hypervisor', 'server_password')
+        self.server_ssh_ip = reader.get('hypervisor', 'server_ssh_ip')
         self.server_ssh_user = reader.get('hypervisor', 'server_ssh_user')
         self.server_ssh_passwd = reader.get('hypervisor', 'server_ssh_passwd')
         self.server_config = reader.get('hypervisor', 'server_config')

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -50,6 +50,7 @@ class Testing(Provision):
             server = self.get_exported_param("HYPERVISOR_{0}_SERVER".format(uid))
             username = self.get_exported_param("HYPERVISOR_{0}_USERNAME".format(uid))
             password = self.get_exported_param("HYPERVISOR_{0}_PASSWORD".format(uid))
+            ssh_ip = self.get_exported_param("HYPERVISOR_{0}_SSH_IP".format(uid))
             ssh_user = self.get_exported_param("HYPERVISOR_{0}_SSH_USER".format(uid))
             ssh_passwd = self.get_exported_param("HYPERVISOR_{0}_SSH_PASSWD".format(uid))
             guest_ip = self.get_exported_param("HYPERVISOR_{0}_GUEST_IP".format(uid))
@@ -62,6 +63,7 @@ class Testing(Provision):
             server = self.get_exported_param("HYPERVISOR_SERVER")
             username = self.get_exported_param("HYPERVISOR_USERNAME")
             password = self.get_exported_param("HYPERVISOR_PASSWORD")
+            ssh_ip = self.get_exported_param("HYPERVISOR_SSH_IP")
             ssh_user = self.get_exported_param("HYPERVISOR_SSH_USER")
             ssh_passwd = self.get_exported_param("HYPERVISOR_SSH_PASSWD")
             guest_ip = self.get_exported_param("GUEST_IP")
@@ -75,6 +77,8 @@ class Testing(Provision):
                 username = config.hypervisor.server_username
             if not password:
                 password = config.hypervisor.server_password
+            if not ssh_ip:
+                ssh_ip = config.hypervisor.server_ssh_ip
             if not ssh_user:
                 ssh_user = config.hypervisor.server_ssh_user
             if not ssh_passwd:
@@ -103,7 +107,8 @@ class Testing(Provision):
             if "//" not in server:
                 server = self.rhevm_admin_get(ssh_hypervisor)
         if "esx" in hypervisor_type:
-            ssh_hypervisor = {"host":server_ip,"username":ssh_user,"password":ssh_passwd}
+            # the ssh_hypervisor of esx is the windows to run powercli command
+            ssh_hypervisor = {"host":ssh_ip,"username":ssh_user,"password":ssh_passwd}
         configs = {
                 'type':hypervisor_type,
                 'server':server,


### PR DESCRIPTION
This pr is used to support vCenter7.0. 
vCenter7.0 is not supported to be deployed in windows any more, only supported to deploy as an application in an ESXi host.
But after researching and testing, we can continue using the powercli in windows to manage the vCenter7.0.
So the vCenter IP will be different with the powercli host IP.

```
# pytest-3 tests/tier1/tc_1053_check_hypervisor_id_and_filter_hosts_option_in_etc_virtwho_d.py tests/tier2/tc_2053_validate_guest_state_when_suspend_resume_stop_start.py 
================================= test session starts =================================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /root/workspace/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.3.0, xdist-1.34.0
collected 2 items                                                                                                                                            

tests/tier1/tc_1053_check_hypervisor_id_and_filter_hosts_option_in_etc_virtwho_d.py .                    [ 50%]
tests/tier2/tc_2053_validate_guest_state_when_suspend_resume_stop_start.py .                              [100%]

=================== 2 passed, 24 warnings in 1206.22s (0:20:06) =============================
```