### PR TITLE
Update tc_2044 to support ahv

### DIFF
--- a/tests/tier2/tc_2044_subscribe_guest_with_activation_key.py
+++ b/tests/tier2/tc_2044_subscribe_guest_with_activation_key.py
@@ -42,7 +42,8 @@ class Testcase(Testing):
             'xen':              'xen_ak',
             'vdsm':             'vdsm_ak',
             'rhevm':            'rhevm_ak',
-            'kubevirt':         'kubevirt_ak'
+            'kubevirt':         'kubevirt_ak',
+            'ahv':              'ahv_ak'
             }
         ak_name = ak_list[hypervisor_type]
         host_uuid = self.get_hypervisor_hostuuid()


### PR DESCRIPTION
Update tc_2044 to support ahv

```
# pytest-3 tests/tier2/tc_2044_subscribe_guest_with_activation_key.py 
================== test session starts ===============================
platform linux -- Python 3.9.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /root/workspace/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.3.0, xdist-1.34.0
collected 1 item                                                                                                                 

tests/tier2/tc_2044_subscribe_guest_with_activation_key.py .                            [100%]

=========================================== 1 passed, 9 warnings in 388.35s (0:06:28) ================
```