### PR TITLE
Update tc_2066 to support vCenter7.0

### DIFF
--- a/tests/tier2/tc_2066_validate_cluster_name_with_special_char.py
+++ b/tests/tier2/tc_2066_validate_cluster_name_with_special_char.py
@@ -35,8 +35,8 @@ class Testcase(Testing):
         host_name = self.get_hypervisor_hostname()
 
         cert = self.vcenter_cert(config['server'], config['username'], config['password'])
-        cluster_name = self.vcenter_cluster_get(cert, ssh_hypervisor)
-        new_cluster_name = "virtwho/test"
+        cluster_name = deploy.vcenter.cluster
+        new_cluster_name = "virtwho/test-" + ''.join(random.sample(string.digits, 6))
 
         # Case Steps
         try:

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2150,24 +2150,25 @@ class Provision(Register):
         cmd = "%s Get-Cluster | select *" % (cert)
         ret, output = self.runcmd(cmd, ssh_cli)
         if ret == 0:
+            name_list = []
             for line in output.splitlines():
                 if re.match(r"^{} .*:".format(option), line):
                     cluster_name = line.split(':')[1].strip()
-                    return cluster_name
+                    name_list.append(cluster_name)
+            return name_list
         else:
             raise FailException("Failed to get cluster {}".format(option))
 
     def vcenter_cluster_name_set(self, cert, ssh_cli, old_name, new_name):
-        if self.vcenter_cluster_get(cert, ssh_cli) == new_name:
-            logger.info("The cluster name is already {}, no need to reset".format(new_name))
+        if new_name in self.vcenter_cluster_get(cert, ssh_cli):
+            logger.info("The cluster name {} is already exist, no need to reset".format(new_name))
             return
         cmd = "{0} Set-Cluster -Cluster {1} -Name {2} -Confirm:$false".format(
             cert, old_name, new_name)
         ret, output = self.runcmd(cmd, ssh_cli)
-        if ret == 0:
-            if self.vcenter_cluster_get(cert, ssh_cli) == new_name:
-                logger.info("Succeeded to set the cluster name to {}".format(new_name))
-                return
+        if ret == 0 and new_name in self.vcenter_cluster_get(cert, ssh_cli):
+            logger.info("Succeeded to set the cluster name {0} to {1}".format(old_name, new_name))
+            return
         else:
             raise FailException("Failed to set the cluster name")
 


### PR DESCRIPTION
The old code just supports one esxi host in the vCenter, but from vCenter7.0, one instance should include more than 1 esxi hosts to provide 2 or more sets of environment. 
- ```self.vcenter_cluster_get()```  gets all cluster names to a list
- ```new cluster name```  contains a random characters to support two triggers meanwhile

```
# pytest tests/tier2/tc_2066_validate_cluster_name_with_special_char.py
=================== test session starts ===================
platform linux -- Python 3.9.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                                                                  

tests/tier2/tc_2066_validate_cluster_name_with_special_char.py .                                                                                                                            [100%]
================= 1 passed, 9 warnings in 299.81s (0:04:59) ====================
```