### PR TITLE
update tc_2067 to support vCenter7.0

### DIFF
--- a/tests/tier2/tc_2067_validate_uniform_mapping_format.py
+++ b/tests/tier2/tc_2067_validate_uniform_mapping_format.py
@@ -25,7 +25,6 @@ class Testcase(Testing):
         # case steps
         logger.info(">>>step1: create json file")
         self.vw_fake_json_create("virt-who -d -p", json_file)
-        ret, fake_json = self.runcmd("cat {0}".format(json_file), self.ssh_host())
         self.vw_etc_d_delete_all()
 
         logger.info(">>>step2: check the mapping in json file is same with debug output")
@@ -34,7 +33,10 @@ class Testcase(Testing):
         else:
             self.vw_fake_conf_create(fake_config_file, json_file, is_hypervisor=True)
         data, tty_output, rhsm_output = self.vw_start(cli='virt-who -do', exp_send=1)
-        results.setdefault('step2', []).append(fake_json in tty_output)
+        ret, fake_json = self.runcmd("cat {0}".format(json_file), self.ssh_host())
+        fake_json_lines = fake_json.split('\n')
+        for line in fake_json_lines:
+            results.setdefault('step2', []).append(line in tty_output)
 
         # case result
         self.vw_case_result(results)


### PR DESCRIPTION
In vCenter7.0, there are 3 esxi hosts and 2 guests (including 1 necessary and default vcls guest) for each hosts, so sometime the guests order are different in debug log and fake json file, so change the code to check each line, not he whole string.

```
# pytest tests/tier2/tc_2067_validate_uniform_mapping_format.py 
============================ test session starts ============================
platform linux -- Python 3.9.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                                                                  

tests/tier2/tc_2067_validate_uniform_mapping_format.py .                                [100%]
```