### PR TITLE
Update the hyperv_guest_uuid function to fix tc_1076 for hyperv mode

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2223,16 +2223,15 @@ class Provision(Register):
         else:
             return False
 
-    def hyperv_guest_uuid(self, ssh_hyperv, guest_name):
+    def hyperv_guest_uuid(self, ssh_hyperv):
         cmd = "powershell (gwmi -Namespace Root\Virtualization\V2 -ClassName Msvm_VirtualSystemSettingData).BiosGUID"
         ret, output = self.runcmd(cmd, ssh_hyperv)
         if ret == 0 and output.strip() is not None: 
-            s = output.strip()
-            if s.startswith('{') and s.endswith('}'):
-                s = s[1:-1]
-            uuid = s[6:8] + s[4:6] + s[2:4] + s[0:2] + "-" + s[11:13] + s[9:11] + "-" + s[16:18] + s[14:16] + s[18:]
-            logger.info("Succeeded to get hyperv guest uuid: {0}".format(uuid))
-            return uuid
+            guest_uuid = output.strip()
+            if guest_uuid.startswith('{') and guest_uuid.endswith('}'):
+                guest_uuid = guest_uuid[1:-1]
+            logger.info("Succeeded to get hyperv guest uuid: {0}".format(guest_uuid))
+            return guest_uuid
         else:
             raise FailException("Failed to get hyperv guest uuid")
 

--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -288,7 +288,7 @@ class Testing(Provision):
             cert = self.vcenter_cert(config['server'], config['username'], config['password'])
             uuid = self.vcenter_guest_uuid(cert, ssh_hypervisor, guest_name)
         if hypervisor_type == "hyperv":
-            uuid = self.hyperv_guest_uuid(ssh_hypervisor, guest_name)
+            uuid = self.hyperv_guest_uuid(ssh_hypervisor)
         if hypervisor_type == "xen":
             uuid = self.xen_guest_uuid(ssh_hypervisor, guest_name)
         if hypervisor_type == "kubevirt":


### PR DESCRIPTION
**Description**
Before changed:
The guest_uuid for hyperv was: `74F3EFFF-296D-5248-A34C-23EE76BB7E8F`
But actually it is `FFEFF374-6D29-4852-A34C-23EE76BB7E8F` which is the core root of the failure for tc_1076.
It is a standard uuid, we don't need to convert the format about guest_uuid now.

**Test Result**
```
[hkx303@kuhuang virtwho-ci]$ nosetests tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
----------------------------------------------------------------------
Ran 1 test in 166.656s

OK
```