### PR TITLE
Update compose url for gating test

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -80,9 +80,9 @@ class Provision(Register):
         if not rhel_compose:
             base_url = deploy.repo.rhel_base
             if 'rhel-9' in rhel_release:
-                url = '{0}/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0.0/COMPOSE_ID'.format(base_url)
+                url = '{0}/rhel-9/nightly/RHEL-9/latest-RHEL-9/COMPOSE_ID'.format(base_url)
             if 'rhel-8' in rhel_release:
-                url = '{0}/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/COMPOSE_ID'.format(base_url)
+                url = '{0}/rhel-8/nightly/RHEL-8/latest-RHEL-8/COMPOSE_ID'.format(base_url)
             if 'rhel-7' in rhel_release:
                 url = '{0}/rhel-7/rel-eng/RHEL-7/latest-RHEL-7/COMPOSE_ID'.format(base_url)
             if 'rhel-6' in rhel_release:


### PR DESCRIPTION
Changed the gating test url to support testing for rhel9.0 and 8.6.
Will not define url for ```latest-RHEL-8.5``` and ```latest-RHEL-9.0.0```, which are replaced with a common ```latest-RHEL-8``` and ```latest-RHEL-9```, because all new virt-who pkg gating test can be run in the latest compose of the lime.