### PR TITLE
Update tc_2020 because the behavior changing for hyperv

### DIFF
--- a/tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py
@@ -24,6 +24,7 @@ class Testcase(Testing):
         msg_list = ["Unable to login|"
                     "incorrect user.*|"
                     "Authentication failure|"
+                    "Authentication failed|"
                     "Incorrect.*username|"
                     "Unauthorized|"
                     "Error.* backend|"


### PR DESCRIPTION
```
# pytest tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py 
==================== test session starts =====================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                                                                  

tests/tier2/tc_2020_validate_password_option_in_etc_virtwho_d.py                                               [100%]

======================== 1 passed, 9 warnings in 426.00s (0:07:06) ========================
```