### PR TITLE
Update tc_1076 to change the guest type of nutanix

### DIFF
--- a/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
+++ b/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
@@ -28,7 +28,7 @@ class Testcase(Testing):
                 'hyperv'            :'hyperv',
                 'xen'               :'xen',
                 'kubevirt'          :'kvm',
-                'ahv'               :'nutanix_ahv'
+                'ahv'               :'kvm'
                 }
 
         # case steps


### PR DESCRIPTION
The guest type of nutanix checked by subscription-manager is `kvm` not `ahv`, which should not be a issue because the nutanix is really based on kvm, or which should not be an virt-who issue because is not caused by virt-who.
```
# pytest tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
============================================================== test session starts ===============================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                 

tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py .      [100%]

============== 1 passed, 9 warnings in 88.18s (0:01:28) ===================
```