### PR TITLE
Update tc_1113 due to bug fixed

### DIFF
--- a/tests/tier1/tc_1113_check_virtwho_status.py
+++ b/tests/tier1/tc_1113_check_virtwho_status.py
@@ -56,9 +56,8 @@ class Testcase(Testing):
             source_conn = f'https://{hypervisor_server}'
         elif 'rhevm' in hypervisor_type:
             source_conn = hypervisor_server.split('ovirt-engine')[0].strip()
-        # There is bug 1987247 for kubevirt mode
         elif 'kubevirt' in hypervisor_type:
-            source_conn = 'xxx'
+            source_conn = deploy.kubevirt.endpoint
         else:
             source_conn = hypervisor_server
         results.setdefault('step4', []).append(
@@ -74,10 +73,12 @@ class Testcase(Testing):
         )
 
         logger.info(">>>step5: Check '#virt-who -s' with bad configuration")
+        option = 'password'
         if 'kubevirt' in hypervisor_type:
-            self.vw_option_update_value('kubeconfig', 'xxx', config_file)
-        else:
-            self.vw_option_update_value('server', 'xxx', config_file)
+            option = 'kubeconfig'
+        if 'libvirt-remote' in hypervisor_type:
+            option = 'server'
+        self.vw_option_update_value(f'{option}', 'xxx', config_file)
         self.vw_option_update_value('owner', 'xxx', config_file)
         status = self.vw_status(cmd='virt-who -s')
         results.setdefault('step5', []).append(


### PR DESCRIPTION
bz1990758 and 2000415 fixed, so update the tc_1113

- kubevirt: the source connection will show the endpoint url.
- ahv: the behavior of  the bad `server` option is not uniform with others, so change to update `password`
- libvirt-remote: `password` is useless, so still keep to change the `server` option

```
# pytest tests/tier1/tc_1113_check_virtwho_status.py 
============================================================== test session starts ===============================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                 

tests/tier1/tc_1113_check_virtwho_status.py .                                                                                              [100%]

```