### PR TITLE
Update tc_1076 to check the guest type by virt-what

### DIFF
--- a/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
+++ b/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
@@ -22,7 +22,6 @@ class Testcase(Testing):
         virt_type = {
                 'libvirt-local'     :'kvm',
                 'libvirt-remote'    :'kvm',
-                'vdsm'              :'rhev',
                 'rhevm'             :'rhev',
                 'esx'               :'vmware',
                 'hyperv'            :'hyperv',
@@ -41,11 +40,16 @@ class Testcase(Testing):
 
         logger.info(">>>step2: check virt.host_type fact by subscription-manager in guest")
         hypervisor_type = self.get_config('hypervisor_type')
-        cmd = "subscription-manager facts --list | grep virt.host_type"
-        ret, output = self.runcmd(cmd, self.ssh_guest())
-        logger.info(output)
-        virt_host_type = output.split(':')[1].strip()
-        results.setdefault('step2', []).append(virt_type[hypervisor_type.lower()] in virt_host_type)
+        _, output1 = self.runcmd("virt-what",
+                                 self.ssh_guest())
+        _, output2 = self.runcmd("subscription-manager facts --list | grep virt.host_type",
+                                 self.ssh_guest())
+        logger.info(output2)
+        results.setdefault('step2', []).append(
+            virt_type[hypervisor_type.lower()] in output1
+            and
+            virt_type[hypervisor_type.lower()] in output2
+        )
 
         logger.info(">>>step3: check virt.is_guest fact by subscription-manager in guest")
         cmd = "subscription-manager facts --list | grep virt.is_guest"


### PR DESCRIPTION
Update step2 to check the `guest type` is match both the results of `#virt-what` and `#subscription-manager facts list`

```
# pytest tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py 
======================== test session starts ========================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                 

tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py .                          [100%]
==================== 1 passed, 9 warnings in 102.76s (0:01:42) =====================
```