### PR TITLE
Update tc_2013 as the server of esx is not expected

### DIFF
--- a/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
+++ b/tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py
@@ -32,7 +32,7 @@ class Testcase(Testing):
         register_config = self.get_register_config()
         register_server = register_config['server']
         hypervisor_config = self.get_hypervisor_config()
-        hypervisor_server = hypervisor_config['ssh_hypervisor']['host']
+        hypervisor_server = hypervisor_config['server']
         good_squid_server = "{0}:{1}".format(deploy.proxy.server, deploy.proxy.port)
         wrong_squid_server = "10.73.3.24:9999"
         types = {'type1': 'http_proxy',


### PR DESCRIPTION
**Description**
Case 2013 failed as the server of esx is not expected

**Testing**
Tested by  
` pytest tests/tier2/tc_2013_validate_unreachable_proxy_by_config.py -s ` for esx an libvirt-remote mode, all passed