### PR TITLE
Udapte satellite_hosts_list function to fix tc_2042 and tc_2043

### DIFF
--- a/virt_who/register.py
+++ b/virt_who/register.py
@@ -843,7 +843,7 @@ class Register(Base):
         username = register_config['username']
         password = register_config['password']
         org_id = self.satellite_org_id_get(ssh, register_config, org_name)
-        cmd = "curl -X GET -s -k -u {0}:{1} '{2}/api/organizations/{3}/hosts'".format(username, password, api, org_id)
+        cmd = "curl -X GET -s -k -u {0}:{1} '{2}/api/organizations/{3}/hosts/?per_page=1000'".format(username, password, api, org_id)
         ret, output = self.runcmd(cmd, ssh, debug=False)
         output = self.is_json(output.strip())
         if ret == 0 and output is not False and output is not None and output != "":


### PR DESCRIPTION
**Description**
the test cases tc_2043 and tc_2043 failed as cannot find the expected host in related org, need to fix it

```
{
  "total": 24,
  "subtotal": 24,
  "page": 1,
  "per_page": 20,
  "search": null,
  "sort": {
    "by": null,
    "order": null
  }
```
we have 24 hosts in satellite but only 20 per_page, that's the key point.

**Test Result**
Tested it in tc_2042, tc_2043, all passed.