### PR TITLE
Maintain tc_2023 due to different behaviors for hypervisor

### DIFF
--- a/tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py
+++ b/tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py
@@ -44,10 +44,7 @@ class Testcase(Testing):
             logger.info(">>>step2: run virt-who with rhsm_port=123")
             self.vw_option_update_value("rhsm_port", "123", config_file)
             data, tty_output, rhsm_output = self.vw_start()
-            error_num = 1
-            if 'RHEL-9' in compose_id:
-                error_num = 2
-            res1 = self.op_normal_value(data, exp_error=error_num, exp_thread=1, exp_send=0)
+            res1 = self.op_normal_value(data, exp_error='1|2', exp_thread=1, exp_send=0)
             error_msg = ["Connection refused|"
                          "Connection timed out"]
             res2 = self.msg_validation(rhsm_output, error_msg)


### PR DESCRIPTION
The error number is not uniform any more for rhel9 when run virt-who-1.31.22-1.el9_0.noarch with bad rhsm_port, but the key error message is acceptable. 

- stage: num=1
- satellite: num=2

**Test Result**
```
# pytest --disable-warnings tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py -v
====================== test session starts ======================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                 

tests/tier2/tc_2023_validate_rhsm_port_option_in_etc_virtwho_d.py::Testcase::test_run PASSED           [100%]

=================== 1 passed, 9 warnings in 517.13s (0:08:37) ==================
```