### PR TITLE
Choose the beaker host to deploy satellite

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1210,7 +1210,7 @@ class Provision(Register):
         reserve = "--reserve --reserve-duration 259200 --priority Urgent"
         job_group = "--job-group=virt-who-ci-server-group"
         if os_type == "virtual":
-            satellite_vm = f'''--hostrequire "<and><system><name op='like' value='{deploy.trigger.satellite_beaker_host}'/></system></and>"'''
+            satellite_vm = f'''--hostrequire "<and><system><name op='like' value='{deploy.trigger.satellite_host}'/></system></and>"'''
             hostrequire = '''{0} --hostrequire "hypervisor!=" --hostrequire "memory > 7000"'''.format(satellite_vm)
         else:
             hostrequire = '''--hostrequire "hypervisor=" --hostrequire "memory > 7000"'''

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1210,10 +1210,9 @@ class Provision(Register):
         reserve = "--reserve --reserve-duration 259200 --priority Urgent"
         job_group = "--job-group=virt-who-ci-server-group"
         if os_type == "virtual":
-            ent_vm = '''--hostrequire "<and><system><name op='like' value='%hp-dl360g9-08-vm%'/></system></and>"'''
-            hostrequire = '''{0} --hostrequire "hypervisor!=" --hostrequire "memory > 7000"'''.format(ent_vm)
+            satellite_vm = f'''--hostrequire "<and><system><name op='like' value='{deploy.trigger.satellite_beaker_host}'/></system></and>"'''
+            hostrequire = '''{0} --hostrequire "hypervisor!=" --hostrequire "memory > 7000"'''.format(satellite_vm)
         else:
-            # hostrequire = '''--hostrequire "hypervisor=" --hostrequire "<cpu><flag value='vmx'/></cpu>" --hostrequire "memory > 4000"'''
             hostrequire = '''--hostrequire "hypervisor=" --hostrequire "memory > 7000"'''
         cmd = '''bkr workflow-simple --prettyxml --variant={0} --arch={1} --distro={2} {3} {4} {5} {6} {7}'''\
                 .format(variant, arch, distro, task, whiteboard, job_group, hostrequire, reserve) 

--- a/virt_who/settings.py
+++ b/virt_who/settings.py
@@ -70,6 +70,7 @@ class SetTrigger(FeatureSettings):
         self.rhel_compose = None
         self.hypervisor_list = None
         self.register_list = None
+        self.satellite_beaker_host = None
         self.rhev_iso = None
         self.brew_package = None
         self.virtwho_upstream = None
@@ -81,6 +82,7 @@ class SetTrigger(FeatureSettings):
         self.rhel_compose = get_exported_param("RHEL_COMPOSE")
         self.hypervisor_list = get_exported_param("HYPERVISOR_LIST")
         self.register_list = get_exported_param("REGISTER_LIST")
+        self.satellite_beaker_host = get_exported_param("SATELLITE_BEAKER_HOST")
         self.rhev_iso = get_exported_param("RHEV_ISO")
         self.brew_package = get_exported_param("VIRTWHO_BREW_PACKAGE")
         self.virtwho_upstream = get_exported_param("VIRTWHO_UPSTREAM")
@@ -95,6 +97,8 @@ class SetTrigger(FeatureSettings):
             self.hypervisor_list = reader.get('trigger', 'hypervisor_list')
         if not self.register_list:
             self.register_list = reader.get('trigger', 'register_list')
+        if not self.satellite_beaker_host:
+            self.satellite_beaker_host = reader.get('trigger', 'satellite_beaker_host')
         if not self.rhev_iso:
             self.rhev_iso = reader.get('trigger', 'rhev_iso')
         if not self.brew_package:

--- a/virt_who/settings.py
+++ b/virt_who/settings.py
@@ -70,7 +70,7 @@ class SetTrigger(FeatureSettings):
         self.rhel_compose = None
         self.hypervisor_list = None
         self.register_list = None
-        self.satellite_beaker_host = None
+        self.satellite_host = None
         self.rhev_iso = None
         self.brew_package = None
         self.virtwho_upstream = None

--- a/virt_who/settings.py
+++ b/virt_who/settings.py
@@ -82,7 +82,7 @@ class SetTrigger(FeatureSettings):
         self.rhel_compose = get_exported_param("RHEL_COMPOSE")
         self.hypervisor_list = get_exported_param("HYPERVISOR_LIST")
         self.register_list = get_exported_param("REGISTER_LIST")
-        self.satellite_beaker_host = get_exported_param("SATELLITE_BEAKER_HOST")
+        self.satellite_host = get_exported_param("SATELLITE_HOST")
         self.rhev_iso = get_exported_param("RHEV_ISO")
         self.brew_package = get_exported_param("VIRTWHO_BREW_PACKAGE")
         self.virtwho_upstream = get_exported_param("VIRTWHO_UPSTREAM")
@@ -97,8 +97,8 @@ class SetTrigger(FeatureSettings):
             self.hypervisor_list = reader.get('trigger', 'hypervisor_list')
         if not self.register_list:
             self.register_list = reader.get('trigger', 'register_list')
-        if not self.satellite_beaker_host:
-            self.satellite_beaker_host = reader.get('trigger', 'satellite_beaker_host')
+        if not self.satellite_host:
+            self.satellite_host = reader.get('trigger', 'satellite_host')
         if not self.rhev_iso:
             self.rhev_iso = reader.get('trigger', 'rhev_iso')
         if not self.brew_package:


### PR DESCRIPTION
The dell-per740-69-vm-01/02/03/04 are ready in beaker, so add an option `SATELLITE_BEAKER_HOST` for user to select where to deploy satellite

- %dell-per740-69-vm%
- %hp-dl360g9-08-vm%

So in our further testing, we can choose one of them when trigger the job

**Test Result**
```
# export SATELLITE_BEAKER_HOST=%dell-per740-69-vm%

[root@yuefliu virtwho-ci]# nosetests tests/tier3/tc_debug.py 
2022-04-07 16:40:49 [INFO] Succeeded to submit beaker job: satellite610-cdn-rhel7
2022-04-07 16:40:49 [INFO] {'satellite610-cdn-rhel7': 'J:6478747'}
2022-04-07 16:40:52 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Pending']
2022-04-07 16:41:55 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Pending']
2022-04-07 16:42:58 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Pending']
2022-04-07 16:44:00 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Pending']
2022-04-07 16:45:03 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Pending']
2022-04-07 16:46:06 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Pending']
2022-04-07 16:47:09 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Pending']
2022-04-07 16:48:12 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Pending']
2022-04-07 16:49:15 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Pending']
2022-04-07 16:50:17 [INFO] Beaker Jobs: {'satellite610-cdn-rhel7': 'J:6478747'}, Jobs status: ['Completed']
.
----------------------------------------------------------------------
Ran 1 test in 577.585s

OK

```

The tc_debug.py is to call the `self.satellite_machines(['satellite610-cdn-rhel7'])`
