### PR TITLE
fix issue for powershell to recognize the select option

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -2177,7 +2177,7 @@ class Provision(Register):
     #*********************************************
     def hyperv_host_uuid(self, ssh_hyperv):
         # Windows UUID needs to be decoded
-        cmd = "powershell gwmi -namespace 'root/cimv2' Win32_ComputerSystemProduct | select *"
+        cmd = '''powershell "gwmi -namespace 'root/cimv2' Win32_ComputerSystemProduct | select *"'''
         ret, output = self.runcmd(cmd, ssh_hyperv, desc="hyperv host uuid check")
         if ret == 0 and "UUID" in output: 
             for line in output.splitlines():
@@ -2237,7 +2237,7 @@ class Provision(Register):
             raise FailException("Failed to get hyperv guest uuid")
 
     def hyperv_guest_status(self, ssh_hyperv, guest_name):
-        cmd = "powershell Get-VM %s | select *" % (guest_name)
+        cmd = '''powershell "Get-VM %s | select *"''' % (guest_name)
         ret, output = self.runcmd(cmd, ssh_hyperv)
         if ret == 0 and output != "":
             for line in output.splitlines():


### PR DESCRIPTION
After upgrading to the windows2022, met below powershell issue, which blocked the hyperv testing, so updated code to fix the issue adding `""` when need to use the `select` option.
```
Command: powershell gwmi -namespace 'root/cimv2' Win32_ComputerSystemProduct | select *
Retcode: 255
Output:
'select' is not recognized as an internal or external command,
operable program or batch file.

```

**TEST RESULT**
```
# pytest tests/tier1/tc_1005_check_virtwho_service_function.py 
========================= test session starts ==========================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                 

tests/tier1/tc_1005_check_virtwho_service_function.py .                                  [100%]

========== 1 passed, 9 warnings in 393.70s (0:06:33) ======
```