### PR TITLE
update virt typr of ahv

### DIFF
--- a/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
+++ b/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
@@ -27,7 +27,7 @@ class Testcase(Testing):
                 'hyperv'            :'hyperv',
                 'xen'               :'xen',
                 'kubevirt'          :'kvm',
-                'ahv'               :'kvm'
+                'ahv'               :'nutanix_ahv'
                 }
 
         # case steps


### PR DESCRIPTION
**Description**
The virt.host_type of ahv guest is not `kvm` any more.
```
# subscription-manager facts --list | grep virt.host_type
virt.host_type: nutanix_ahv
```

**Test Reulst**
```
# pytest tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py --disable-warnings 
============================ test session starts ============================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                 

tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py .                                     [100%]
=============== 1 passed, 9 warnings in 98.11s (0:01:38) ==============
```