### PR TITLE
update the repos to install satellite

### DIFF
--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1370,9 +1370,7 @@ class Provision(Register):
         sat_host = ssh_sat['host']
         cmd = "subscription-manager repos \
                 --enable=rhel-{0}-server-satellite-maintenance-6-rpms \
-                --enable=rhel-{0}-server-satellite-capsule-{1}-rpms \
                 --enable=rhel-{0}-server-satellite-{1}-rpms \
-                --enable=rhel-{0}-server-satellite-tools-{1}-rpms \
                 --enable=rhel-{0}-server-ansible-2.9-rpms".format(rhel_ver, sat_ver)
         status, output = self.run_loop(cmd, ssh_sat, desc="enable satellite repos")
         if status != "Yes":


### PR DESCRIPTION
remove the `--enable=rhel-{0}-server-satellite-capsule-{1}-rpms` and `--enable=rhel-{0}-server-satellite-tools-{1}-rpms`, which run failed in CI and should be not necessary as the document.