### PR TITLE
Update the ahv hypervisor.type in tc_1108

### DIFF
--- a/tests/tier1/tc_1108_check_hypervisor_facts.py
+++ b/tests/tier1/tc_1108_check_hypervisor_facts.py
@@ -38,8 +38,11 @@ class Testcase(Testing):
             'esx': 'VMware ESXi',
             'libvirt-remote': 'QEMU',
             'rhevm': 'qemu',
-            'ahv': 'ahv'
+            'ahv': 'AHV'
         }
+        if hypervisor_type == 'ahv' and deploy.ahv.api_version == 'v2':
+            type_values['ahv'] = 'kKvm'
+
         cluster_values = {
             'esx': deploy.vcenter.cluster,
             'rhevm': deploy.rhevm.cluster,

--- a/virt_who/settings.py
+++ b/virt_who/settings.py
@@ -586,6 +586,7 @@ class SetAhv(FeatureSettings):
         self.master_user = None
         self.master_passwd = None
         self.cluster = None
+        self.api_version = None
         self.guest_name = None
         self.guest_user = None
         self.guest_passwd = None
@@ -599,6 +600,7 @@ class SetAhv(FeatureSettings):
         self.master_user = reader.get('ahv', 'master_user')
         self.master_passwd = reader.get('ahv', 'master_passwd')
         self.cluster = reader.get('ahv', 'cluster')
+        self.api_version = reader.get('ahv', 'api_version')
         self.guest_name = reader.get('ahv', 'guest_name')
         self.guest_user = reader.get('ahv', 'guest_user')
         self.guest_passwd = reader.get('ahv', 'guest_passwd')


### PR DESCRIPTION
**Description**
Based on https://bugzilla.redhat.com/show_bug.cgi?id=1985232#c3, we changed the ahv hypervisor type to 

- api_version=v2: `kKvm`
- api_version=v3: `AHV`

BTW: because we never developed the ahv functions in virtwho-ci, so will directly set the `ahv.api_version=` value in provison.ini file.


**Test Result**
#pytest --disable-warnings -v tests/tier1/tc_1108_check_hypervisor_facts.py 
=================== test session starts =========================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                 

tests/tier1/tc_1108_check_hypervisor_facts.py::Testcase::test_run PASSED       [100%]

======================= 1 passed, 9 warnings in 181.18s (0:03:01) =========