### PR TITLE
Fix issue of tc_2052

### DIFF
--- a/tests/tier2/tc_2052_validate_hypervisors_connection.py
+++ b/tests/tier2/tc_2052_validate_hypervisors_connection.py
@@ -17,8 +17,8 @@ class Testcase(Testing):
         config_name = "virtwho-config"
         config_file = "/etc/virt-who.d/{0}.conf".format(config_name)
         self.vw_option_enable('[global]', '/etc/virt-who.conf')
-        self.vw_option_enable('debug', '/etc/virt-who.conf')
-        self.vw_option_update_value('debug', 'True', '/etc/virt-who.conf')
+        # self.vw_option_enable('debug', '/etc/virt-who.conf')
+        # self.vw_option_update_value('debug', 'True', '/etc/virt-who.conf')
         self.vw_option_enable('interval', '/etc/virt-who.conf')
         self.vw_option_update_value('interval', '60', '/etc/virt-who.conf')
         self.vw_etc_d_mode_create(config_name, config_file)


### PR DESCRIPTION
In rhel9 testing, the tc_2052 fails for each hypervisor because the log of `[rhsm.connection DEBUG] MainProcess(611961):Thread-3 @connection.py:_request:1087 - Connection timeout: 15 is used from 'Keep-Alive' HTTP header`, which contains keywork `timeout` so impacts the assert result.
There are two methods to fix this issue

1.  hide all the debug log, so will not get the [rhsm.connection DEBUG]  log
2.  remove the assertion of the `timeout` and `time out`

And have tried the both methods for each hypervisor, both pass for hyperv, kubevirt, rhevm, libvirt, but failed with `esx and ahv` because virt-who cannot automatically get the error after disconnecting the hypervisor, which may be a issue and will research it deeply.

```
# pytest tests/tier2/tc_2052_validate_hypervisors_connection.py 
===================== test session starts =====================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                                                                  

tests/tier2/tc_2052_validate_hypervisors_connection.py .                                        [100%]
===================== 1 passed, 9 warnings in 464.05s (0:07:44) =========================
```