### PR TITLE
Fix issue of tc_1076 for rhevm mode

### DIFF
--- a/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
+++ b/tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py
@@ -22,7 +22,7 @@ class Testcase(Testing):
         virt_type = {
                 'libvirt-local'     :'kvm',
                 'libvirt-remote'    :'kvm',
-                'rhevm'             :'rhev',
+                'rhevm'             :'kvm',
                 'esx'               :'vmware',
                 'hyperv'            :'hyperv',
                 'xen'               :'xen',


### PR DESCRIPTION
Our two set of rhevm environment have different behavior for this case,

1. env 83 guest: virt.host_type: kvm
2. env 85 guest: virt.host_type: rhev, kvm

Which difference may because the different rhevm version (4.3 or 4.4) or because of different guest (el8 or el9), but because the rhevm mode has been in the deprecated list and this issue is not the virt-who problem, so will not report bug. 
This pr will change to use the `kvm` as assertion to pass this case.

**Test Result**
```
# pytest --disable-warnings -v tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py 
========================= test session starts ==========================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                                                                  

tests/tier1/tc_1076_check_guest_facts_by_subscription_manager.py::Testcase::test_run PASSED                         [100%]


```