### PR TITLE
Skip fetch the dmi.system.uuid for rhel8.4 around ahv

### DIFF
--- a/virt_who/testing.py
+++ b/virt_who/testing.py
@@ -773,7 +773,10 @@ class Testing(Provision):
                     facts['type'] = item['facts']['hypervisor.type']
                     facts['version'] = item['facts']['hypervisor.version']
                     facts['socket'] = item['facts']['cpu.cpu_socket(s)']
-                    facts['dmi'] = item['facts']['dmi.system.uuid']
+                    # ahv for rhel8.4 connot get the dmi.system.uuid now
+                    if 'RHEL-8.4' not in self.get_config('rhel_compose') and \
+                            'ahv' not in self.get_config('hypervisor_type'):
+                        facts['dmi'] = item['facts']['dmi.system.uuid']
                     if 'hypervisor.cluster' in item['facts'].keys():
                         facts['cluster'] = item['facts']['hypervisor.cluster']
                     else:


### PR DESCRIPTION
**Description**
As subject, to fix the error:
`KeyError: 'dmi.system.uuid'`

**Test Result**
```
[hkx303@kuhuang virtwho-ci]$ pytest tests/tier1/tc_1008_check_virtwho_fetch_and_send_function_by_virtwho_d.py -s
========================== 1 passed, 1 warning in 174.71s (0:02:54) ==========================
```

