### PR TITLE
fix tc_1004 issue for z-stream testing

### DIFF
--- a/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
+++ b/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
@@ -23,9 +23,12 @@ class Testcase(Testing):
         logger.info(">>>step2: virt-who-config have correct man page")
         ret, output = self.runcmd("man virt-who-config", self.ssh_host())
         results.setdefault('step2', []).append("configuration for virt-who" in output)
-        msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, xen, or.*\n.*kubevirt"
-        if "RHEL-9" in compose_id:
+        if "RHEL-8.4" in compose_id:
+            msg = "backend names: libvirt, esx, rhevm, hyperv, fake, xen, or kube.*\n.*virt."
+        elif "RHEL-9" in compose_id:
             msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, or kube.*\n.*virt."
+        else:
+            msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, xen, or.*\n.*kubevirt"
         results.setdefault('step2', []).append(self.vw_msg_search(output, msg))
 
         logger.info(">>>step3: virt-who have correct help page")


### PR DESCRIPTION
Test Result
```
# pytest --disable-warnings -v tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py 
============================================================== test session starts ===============================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/workspace/virtwho-ci
collected 1 item                                                                                                                                 

tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py::Testcase::test_run PASSED      
```