### PR TITLE
fix pytest build issue after jenkins upgrade to 2.361.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrdict==2.0.1
 paramiko==2.10.1
-pytest==5.4.3
+pytest==6.2.5
 pytest-services==1.3.1
 pytest-mock==1.10.4
 pytest-xdist==1.34.0


### PR DESCRIPTION
```
 File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "/usr/local/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 143, in exec_module
    source_stat, co = _rewrite_test(fn, self.config)
  File "/usr/local/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 330, in _rewrite_test
    co = compile(tree, fn, "exec", dont_inherit=True)
TypeError: required field "lineno" missing from alias
/home/jenkins/workspace/runtest-gating
```