### PR TITLE
Suppport satellite6.12 for virt-who jenkins

### DIFF
--- a/utils/installer.py
+++ b/utils/installer.py
@@ -71,9 +71,12 @@ def install_satellite(args):
         provision.satellite_repo_enable(ssh_sat, sat_ver, rhel_ver)
     if "cdn" in sat_type:
         provision.employee_sku_attach(ssh_sat)
-        provision.rhel_repo_enable(ssh_sat)
-        provision.satellite_cdn_pool_attach(ssh_sat)
-        provision.satellite_cdn_repo_enable(ssh_sat, sat_ver, rhel_ver)
+        if rhel_ver == "8":
+            provision.satellite_cdn_repo_config(ssh_sat, sat_ver, rhel_ver)
+        else:
+            provision.rhel_repo_enable(ssh_sat)
+            provision.satellite_cdn_pool_attach(ssh_sat)
+            provision.satellite_cdn_repo_enable(ssh_sat, sat_ver, rhel_ver)
     if "nightly" in sat_type:
         provision.employee_sku_attach(ssh_sat)
         provision.rhel_repo_enable(ssh_sat)

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -1396,6 +1396,21 @@ class Provision(Register):
             raise FailException("Failed to enable satellite repos({0})".format(sat_host))
         logger.info("Succeeded to enable satellite repos({0})".format(sat_host))
 
+    def satellite_cdn_repo_config(self, ssh_sat, sat_ver, rhel_ver):
+        sat_host = ssh_sat['host']
+        cmd = "subscription-manager repos \
+                --enable=rhel-{0}-for-x86_64-baseos-rpms \
+                --enable=rhel-{0}-for-x86_64-appstream-rpms \
+                --enable=satellite-{1}-for-rhel-{0}-x86_64-rpms \
+                --enable=satellite-maintenance-{1}-for-rhel-{0}-x86_64-rpms".format(rhel_ver, sat_ver)
+        status, output = self.run_loop(cmd, ssh_sat, desc="enable satellite repos")
+        if status != "Yes":
+            raise FailException("Failed to enable satellite repos({0})".format(sat_host))
+        logger.info("Succeeded to enable satellite repos({0})".format(sat_host))
+        if rhel_ver == "8":
+            cmd = "dnf -y module enable satellite:el8"
+            _, output = self.runcmd(cmd, ssh_sat, desc="enable satellite rhel8 module")
+
     def satellite_qa_dogfood_enable(self, ssh_sat, sat_ver, rhel_ver, repo_type="satellite"):
         '''repo_type should be one of them: satellite, capsule, satellite-tools'''
         repo = deploy.repo.rhel_sat


### PR DESCRIPTION
Now, steps to deploy satellite 6.12 on rhel8:
https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html-single/installing_satellite_server_in_a_connected_network_environment/index#configuring-repositories_satellite

```
# subscription-manager repos --disable "*"

# subscription-manager repos --enable=rhel-8-for-x86_64-baseos-rpms \
--enable=rhel-8-for-x86_64-appstream-rpms \
--enable=satellite-6.12-for-rhel-8-x86_64-rpms \
--enable=satellite-maintenance-6.12-for-rhel-8-x86_64-rpms

# dnf module enable satellite:el8
```