### PR TITLE
update tc_1004 due to rhevm unsupported for rhel9

### DIFF
--- a/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
+++ b/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
@@ -26,7 +26,7 @@ class Testcase(Testing):
         if "RHEL-8.4" in compose_id:
             msg = "backend names: libvirt, esx, rhevm, hyperv, fake, xen, or kube.*\n.*virt."
         elif "RHEL-9" in compose_id:
-            msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, or kube.*\n.*virt."
+            msg = "backend names: ahv, libvirt, esx, hyperv, fake, or kubevirt."
         else:
             msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, xen, or.*\n.*kubevirt"
         results.setdefault('step2', []).append(self.vw_msg_search(output, msg))


### PR DESCRIPTION
**Description**
rhevm mode has been removed from rhel9, so update the test case to match the new feature.

**Test Result**
```
% python3 -m pytest -v tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py 
========================================================= test session starts =========================================================
platform darwin -- Python 3.9.6, pytest-7.2.0, pluggy-1.0.0 -- /Library/Developer/CommandLineTools/usr/bin/python3
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-ci
collected 1 item                                                                                                                      

tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py::Testcase::test_run PASSED                          [100%]

==================================================== 1 passed, 2 warnings in 2.62s ===================
```