### PR TITLE
fix gating test issue to get pkg_url

### DIFF
--- a/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
+++ b/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
@@ -26,7 +26,7 @@ class Testcase(Testing):
         if "RHEL-8.4" in compose_id:
             msg = "backend names: libvirt, esx, rhevm, hyperv, fake, xen, or kube.*\n.*virt."
         elif "RHEL-9" in compose_id:
-            msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, or kube.*\n.*virt."
+            msg = "backend names: ahv, libvirt, esx, hyperv, fake, or kubevirt."
         else:
             msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, xen, or.*\n.*kubevirt"
         results.setdefault('step2', []).append(self.vw_msg_search(output, msg))

--- a/virt_who/provision.py
+++ b/virt_who/provision.py
@@ -79,7 +79,7 @@ class Provision(Register):
             source = ''
         cmd = 'curl -k -s -i {0}'.format(brew_build_url)
         output = os.popen(cmd).read()
-        pkg_url = re.findall(r'<a href="http://(.*?).noarch.rpm">download</a>', output)[-1]
+        pkg_url = re.findall(r'<a href="https://(.*?).noarch.rpm">download</a>', output)[-1]
         items = pkg_url.split('/')
         rhel_release = items[3]
         rhel_compose = self.get_exported_param("RHEL_COMPOSE")


### PR DESCRIPTION
Failed to get the `pkg_url` from `CI_MESSAGE` with below issue, which is because the bad regular expression, it should be `https` not `http`.

```
Traceback (most recent call last):
  File "/Users/yuefliu/workspace/virtwho-ci/tests/tier3/tc_debug.py", line 113, in test_run
    env = self.ci_msg_parser()
  File "/Users/yuefliu/workspace/virtwho-ci/virt_who/provision.py", line 83, in ci_msg_parser
    pkg_url = re.findall(r'<a href="http://(.*?).noarch.rpm">download</a>', output)[-1]
IndexError: list index out of range
```