### PR TITLE
update the tc2035 as the 1910274 WONTFIX

### DIFF
--- a/tests/tier2/tc_2035_validate_global_report_id_by_virtwho_conf.py
+++ b/tests/tier2/tc_2035_validate_global_report_id_by_virtwho_conf.py
@@ -13,6 +13,8 @@ class Testcase(Testing):
         # Case Config
         results = dict()
         virtwho_conf = "/etc/virt-who.conf"
+        register_config = self.get_register_config()
+        register_type = register_config['type']
         self.vw_option_enable('[global]', virtwho_conf)
         self.vw_option_enable('debug', virtwho_conf)
         self.vw_option_update_value('debug', 'True', virtwho_conf)
@@ -23,6 +25,8 @@ class Testcase(Testing):
         reporter_id_non_ascii = "红帽©¥®ðπ∉"
         steps = {'step2': reporter_id_null,
                  'step3': reporter_id_non_ascii}
+        if "satellite" in register_type:
+            del steps['step3']
 
         # Case Steps
         logger.info(">>>step1: get default reporter_id")
@@ -55,7 +59,7 @@ class Testcase(Testing):
         # Case Result
         notes = list()
         notes.append("Bug(step2): virt-who still uses null value for reporter_id")
-        notes.append("BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1750206")
+        notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1750206")
         notes.append("Bug(step3): error when configured the report_id with special")
-        notes.append("BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1910274")
+        notes.append("Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1910274")
         self.vw_case_result(results, notes)


### PR DESCRIPTION
**Description**
update the tc2035 as the BZ1910274 WONTFIX

**Test Result**
```
[hkx303@kuhuang virtwho-ci]$ pytest tests/tier2/tc_2035_validate_global_report_id_by_virtwho_conf.py -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.8.0, pluggy-0.13.1
rootdir: /home/hkx303/Documents/CI/virtwho-ci
plugins: services-1.3.1, mock-1.10.4, forked-1.0.2, ibutsu-1.0.34, cov-2.7.1, xdist-1.34.0
collected 1 item                                                                             

tests/tier2/tc_2035_validate_global_report_id_by_virtwho_conf.py 2023-02-02 19:22:30 [INFO] ++++++++++++++++++++++++++++++
2023-02-02 19:22:30 [INFO] RHEL-136716:tc_2035_validate_global_report_id_by_virtwho_conf.py
2023-02-02 19:23:35 [INFO] Succeeded to get esxi host uuid: e3514d56-e50e-1426-5b61-ba8cc5b5609e
2023-02-02 19:23:37 [INFO] Succeeded to get satellite host_id: bootp-73-213-185.lab.eng.pek2.redhat.com:3363
2023-02-02 19:23:40 [INFO] Succeeded to delete host: bootp-73-213-185.lab.eng.pek2.redhat.com
2023-02-02 19:23:44 [INFO] Succeeded to unregister and clean system(10.73.131.160:56136)
2023-02-02 19:24:03 [INFO] Succeeded to register system 10.73.131.160:56136 to hp-dl360g9-08-vm-03.rhts.eng.pek2.redhat.com(satellite612-cdn-rhel8)
2023-02-02 19:24:07 [INFO] Succeeded to unregister and clean system(10.73.212.127)
2023-02-02 19:24:19 [INFO] Succeeded to register system 10.73.212.127 to hp-dl360g9-08-vm-03.rhts.eng.pek2.redhat.com(satellite612-cdn-rhel8)
2023-02-02 19:24:20 [INFO] Succeeded to disable all options in /etc/virt-who.conf
2023-02-02 19:24:21 [INFO] Succeeded to disable all options in /etc/sysconfig/virt-who
2023-02-02 19:24:22 [INFO] Succeeded to delete all files in /etc/virt-who.d/
2023-02-02 19:24:23 [INFO] Succeeded to enable option \[global\]
2023-02-02 19:24:23 [INFO] Succeeded to enable option debug
2023-02-02 19:24:24 [INFO] Succeeded to set option debug value to True
2023-02-02 19:24:27 [INFO] Succeeded to create config file /etc/virt-who.d/virtwho-config.conf
2023-02-02 19:24:27 [INFO] >>>step1: get default reporter_id
2023-02-02 19:24:42 [INFO] Start to run virt-who by service
2023-02-02 19:25:09 [INFO] pending_job: 0, is_429: no, loop_num: 0, loop_time: -1, send_num: 1, error_num: 0, thread_num: 1
2023-02-02 19:25:09 [INFO] virt-who is terminated by expected_send and expected_loop ready
2023-02-02 19:25:28 [INFO] Succeeded to get satellite host_id: bootp-73-213-185.lab.eng.pek2.redhat.com:3366
2023-02-02 19:25:30 [INFO] Succeeded to get satellite host_id: bootp-73-213-186.lab.eng.pek2.redhat.com:1350
2023-02-02 19:25:32 [INFO] Succeeded to get satellite host_id: bootp-73-213-183.lab.eng.pek2.redhat.com:1353
2023-02-02 19:25:34 [INFO] Succeeded to get satellite host_id: bootp-73-213-187.lab.eng.pek2.redhat.com:1352
2023-02-02 19:25:34 [INFO] virtwho thread number(1) is expected
2023-02-02 19:25:34 [INFO] virtwho error number(0) is expected
2023-02-02 19:25:34 [INFO] virtwho send number(1) is expected
2023-02-02 19:25:34 [INFO] Finished to validate all the expected options
2023-02-02 19:25:34 [INFO] default reporter_id is rhel-8-8-0-20230114-0-esx-56136.redhat.com-3cb9bec266ba4bf095ded9a722255ca2
2023-02-02 19:25:34 [INFO] >>>step2: run virt-who to check reporter_id()
2023-02-02 19:25:35 [INFO] Succeeded to enable option reporter_id
2023-02-02 19:25:36 [INFO] Succeeded to set option reporter_id value to 
2023-02-02 19:25:51 [INFO] Start to run virt-who by service
2023-02-02 19:26:19 [INFO] pending_job: 0, is_429: no, loop_num: 0, loop_time: -1, send_num: 1, error_num: 0, thread_num: 1
2023-02-02 19:26:19 [INFO] virt-who is terminated by expected_send and expected_loop ready
2023-02-02 19:26:38 [INFO] Succeeded to get satellite host_id: bootp-73-213-185.lab.eng.pek2.redhat.com:3366
2023-02-02 19:26:40 [INFO] Succeeded to get satellite host_id: bootp-73-213-186.lab.eng.pek2.redhat.com:1350
2023-02-02 19:26:42 [INFO] Succeeded to get satellite host_id: bootp-73-213-183.lab.eng.pek2.redhat.com:1353
2023-02-02 19:26:44 [INFO] Succeeded to get satellite host_id: bootp-73-213-187.lab.eng.pek2.redhat.com:1352
2023-02-02 19:26:44 [INFO] virtwho thread number(1) is expected
2023-02-02 19:26:44 [INFO] virtwho error number(0) is expected
2023-02-02 19:26:44 [INFO] virtwho send number(1) is expected
2023-02-02 19:26:44 [INFO] Finished to validate all the expected options
2023-02-02 19:26:44 [INFO] Succeeded to check, reporter_id(rhel-8-8-0-20230114-0-esx-56136.redhat.com-3cb9bec266ba4bf095ded9a722255ca2) is expected
2023-02-02 19:26:44 [WARNING] Bug(step2): virt-who still uses null value for reporter_id
2023-02-02 19:26:44 [WARNING] BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1750206
2023-02-02 19:26:44 [WARNING] Bug(step3): error when configured the report_id with special
2023-02-02 19:26:44 [WARNING] BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1910274
2023-02-02 19:26:44 [INFO] Succeeded to run case, all steps passed

========================== 1 passed, 1 warning in 254.46s (0:04:14) ==========================
```