### PR TITLE
Update tc_1105 due to new behavior

### DIFF
--- a/tests/tier1/tc_1105_check_rhsm_proxy_function_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1105_check_rhsm_proxy_function_in_etc_virtwho_d.py
@@ -33,7 +33,7 @@ class Testcase(Testing):
         proxy_port = deploy.proxy.port
         bad_proxy_server = "xxx.eng.pek2.redhat.com"
         bad_proxy_port = "0000"
-        error_msg = "Connection refused|Unable to connect to: .*{0}".format(bad_proxy_server)
+        error_msg = "Connection refused|Unable to connect to: .*{0}|Proxy error at .*{0}}".format(bad_proxy_server)
 
         # Case Steps
         try:

--- a/tests/tier1/tc_1105_check_rhsm_proxy_function_in_etc_virtwho_d.py
+++ b/tests/tier1/tc_1105_check_rhsm_proxy_function_in_etc_virtwho_d.py
@@ -33,7 +33,7 @@ class Testcase(Testing):
         proxy_port = deploy.proxy.port
         bad_proxy_server = "xxx.eng.pek2.redhat.com"
         bad_proxy_port = "0000"
-        error_msg = "Connection refused|Unable to connect to: .*{0}|Proxy error at .*{0}}".format(bad_proxy_server)
+        error_msg = "Connection refused|Unable to connect to: .*{0}|Proxy error at .*{0}".format(bad_proxy_server)
 
         # Case Steps
         try:


### PR DESCRIPTION
**Description**
The latest` subscription-manager-1.29.32` brought a new behavior for virt-who, when configure bad proxy, the error message changed to `Proxy error at xxx`, which could be a reasonable log, so update the code to match it.

**Test Result**
```
python3 -m pytest -v tests/tier1/tc_1105_check_rhsm_proxy_function_in_etc_virtwho_d.py
========================================================= test session starts =========================================================
platform darwin -- Python 3.9.6, pytest-7.2.0, pluggy-1.0.0 -- /Library/Developer/CommandLineTools/usr/bin/python3
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-ci
collected 1 item                                                                                                                      

tests/tier1/tc_1105_check_rhsm_proxy_function_in_etc_virtwho_d.py::Testcase::test_run PASSED                                    [100%]

============================================== 1 passed, 2 warnings in 520.96s (0:08:40) =======================
```