### PR TITLE
skip all the tests for unlimit, limit and instance sku

### DIFF
--- a/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
+++ b/tests/tier1/tc_1004_check_virtwho_virtwhoconfig_man_page_and_help_exist.py
@@ -27,6 +27,8 @@ class Testcase(Testing):
             msg = "backend names: libvirt, esx, rhevm, hyperv, fake, xen, or kube.*\n.*virt."
         elif "RHEL-9" in compose_id:
             msg = "backend names: ahv, libvirt, esx, hyperv, fake, or kubevirt."
+            if "RHEL-9.0" in compose_id or "RHEL-9.1" in compose_id:
+                msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, or kube.*\n.*virt."
         else:
             msg = "backend names: ahv, libvirt, esx, rhevm, hyperv, fake, xen, or.*\n.*kubevirt"
         results.setdefault('step2', []).append(self.vw_msg_search(output, msg))

--- a/tests/tier1/tc_1079_check_unlimited_virtual_pool_created_in_guest.py
+++ b/tests/tier1/tc_1079_check_unlimited_virtual_pool_created_in_guest.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134065')
+        self.vw_case_skip("unlimited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1080_check_unlimited_virtual_pool_attached_by_poolId_in_guest.py
+++ b/tests/tier1/tc_1080_check_unlimited_virtual_pool_attached_by_poolId_in_guest.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134067')
+        self.vw_case_skip("unlimited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1081_check_unlimited_virtual_pool_attached_by_auto_in_guest.py
+++ b/tests/tier1/tc_1081_check_unlimited_virtual_pool_attached_by_auto_in_guest.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134069')
+        self.vw_case_skip("unlimited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1082_check_unlimited_virtual_pool_revoked_in_guest_after_host_unattached.py
+++ b/tests/tier1/tc_1082_check_unlimited_virtual_pool_revoked_in_guest_after_host_unattached.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134071')
+        self.vw_case_skip("unlimited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1083_check_unlimited_virtual_pool_revoked_in_guest_after_host_unregister.py
+++ b/tests/tier1/tc_1083_check_unlimited_virtual_pool_revoked_in_guest_after_host_unregister.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134072')
+        self.vw_case_skip("unlimited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1092_check_limited_virtual_pool_created_in_guest.py
+++ b/tests/tier1/tc_1092_check_limited_virtual_pool_created_in_guest.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134068')
+        self.vw_case_skip("limited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1093_check_limited_virtual_pool_attached_by_poolId_in_guest.py
+++ b/tests/tier1/tc_1093_check_limited_virtual_pool_attached_by_poolId_in_guest.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134073')
+        self.vw_case_skip("limited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1094_check_limited_virtual_pool_attached_by_auto_in_guest.py
+++ b/tests/tier1/tc_1094_check_limited_virtual_pool_attached_by_auto_in_guest.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134054')
+        self.vw_case_skip("limited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1095_check_limited_virtual_pool_revoked_in_guest_after_host_unattached.py
+++ b/tests/tier1/tc_1095_check_limited_virtual_pool_revoked_in_guest_after_host_unattached.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134053')
+        self.vw_case_skip("limited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1096_check_limited_virtual_pool_revoked_in_guest_after_host_unregister.py
+++ b/tests/tier1/tc_1096_check_limited_virtual_pool_revoked_in_guest_after_host_unregister.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134058')
+        self.vw_case_skip("limited sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1097_check_instance_no_virtual_pool_created_in_guest.py
+++ b/tests/tier1/tc_1097_check_instance_no_virtual_pool_created_in_guest.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134075')
+        self.vw_case_skip("instance sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1098_check_instance_consumed_status_in_host_after_set_cpu_socket_1.py
+++ b/tests/tier1/tc_1098_check_instance_consumed_status_in_host_after_set_cpu_socket_1.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134076')
+        self.vw_case_skip("instance sku")
         hypervisor_type = self.get_config('hypervisor_type')
         if hypervisor_type not in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)

--- a/tests/tier1/tc_1099_check_instance_consumed_status_in_host_after_set_cpu_socket_8.py
+++ b/tests/tier1/tc_1099_check_instance_consumed_status_in_host_after_set_cpu_socket_8.py
@@ -8,6 +8,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134077')
+        self.vw_case_skip("instance sku")
         hypervisor_type = self.get_config('hypervisor_type')
         if hypervisor_type not in ('libvirt-local', 'vdsm'):
             self.vw_case_skip(hypervisor_type)

--- a/tests/tier1/tc_1100_check_instance_consumed_status_by_auto_in_host_after_set_cpu_socket_8.py
+++ b/tests/tier1/tc_1100_check_instance_consumed_status_by_auto_in_host_after_set_cpu_socket_8.py
@@ -8,6 +8,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134078')
+        self.vw_case_skip("instance sku")
         hypervisor_type = self.get_config('hypervisor_type')
         trigger_type = self.get_config('trigger_type')
         if hypervisor_type not in ('libvirt-local', 'vdsm'):

--- a/tests/tier1/tc_1101_check_instance_consumed_status_in_guest_after_set_cpu_socket_1.py
+++ b/tests/tier1/tc_1101_check_instance_consumed_status_in_guest_after_set_cpu_socket_1.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134079')
+        self.vw_case_skip("instance sku")
         self.vw_case_init()
 
         # case config

--- a/tests/tier1/tc_1102_check_instance_consumed_status_in_guest_after_set_cpu_socket_8.py
+++ b/tests/tier1/tc_1102_check_instance_consumed_status_in_guest_after_set_cpu_socket_8.py
@@ -7,6 +7,7 @@ from virt_who.testing import Testing
 class Testcase(Testing):
     def test_run(self):
         self.vw_case_info(os.path.basename(__file__), case_id='RHEL-134080')
+        self.vw_case_skip("instance sku")
         self.vw_case_init()
 
         # case config


### PR DESCRIPTION
after stage refresh, the RH00204 SKU couldn't be found by Ethel, and because we have decided to only support the vdc sku in the testing, so skip all other ones.