### PR TITLE
Fix the error when getting the gateway for hypervisor

### DIFF
--- a/virt_who/base.py
+++ b/virt_who/base.py
@@ -346,7 +346,7 @@ class Base(unittest.TestCase):
 
     def get_gateway(self, ssh):
         ipaddr = self.get_ipaddr(ssh)
-        cmd = "ip route | grep %s" % ipaddr
+        cmd = "ip route | grep %s | grep /" % ipaddr
         ret, output = self.runcmd(cmd, ssh)
         if ret == 0 and output is not None and output != "":
             output = output.strip().split(" ")


### PR DESCRIPTION
**Description**
CI failed when getting the gateway for the hypervisor:
```
>>> Running in: 10.73.131.248:22, Desc: None
Command: ip route | grep 10.73.131.248
Retcode: 0
Output:
default via 10.73.131.254 dev enp1s0 proto dhcp src 10.73.131.248 metric 100 
10.73.130.0/23 dev enp1s0 proto kernel scope link src 10.73.131.248 metric 100 
 

>>> Running in: 10.73.131.248:22, Desc: check ip addr by mac
Command: nmap -sP -n default | grep -i -B 2 56:6f:90:2f:00:02 |grep 'Nmap scan report for' | grep -Eo '([0-9]{1,3}[\.]){3}[0-9]{1,3}'| tail -1
Retcode: 0
Output:
Failed to resolve "default".
WARNING: No targets were specified, so 0 hosts scanned. 
```

The root cause is the rhel8.7 system will have 2 lines from the command when we would like to get the gateway, add `'grep /'` to select the specific line