### PR TITLE
tc_1002: unregister virt-who host before run steps

### DIFF
--- a/tests/tier1/tc_1002_check_virtwho_can_be_installed_and_uninstalled.py
+++ b/tests/tier1/tc_1002_check_virtwho_can_be_installed_and_uninstalled.py
@@ -10,6 +10,8 @@ class Testcase(Testing):
         trigger_type = self.get_config('trigger_type')
         if trigger_type in ('trigger-rhev', 'trigger-brew', 'trigger-multiarch'):
             self.vw_case_skip(trigger_type)
+        # unregister in advance to avoid impacting the pkg install from repository.
+        self.system_unregister(self.ssh_host())
 
         # case config
         results = dict()


### PR DESCRIPTION
unregister in advance to avoid impacting the pkg installing from repository.

**test result**
```
% python3 -m pytest -v tests/tier1/tc_1002_check_virtwho_can_be_installed_and_uninstalled.py
========================================================= test session starts =========================================================
platform darwin -- Python 3.9.6, pytest-7.2.0, pluggy-1.0.0 -- /Library/Developer/CommandLineTools/usr/bin/python3
cachedir: .pytest_cache
rootdir: /Users/yuefliu/workspace/virtwho-ci
collected 1 item                                                                                                                      

tests/tier1/tc_1002_check_virtwho_can_be_installed_and_uninstalled.py::Testcase::test_run PASSED                                [100%]
```