### PR TITLE
tc_2067: update for local mode due to bz1933578 wontfix

### DIFF
--- a/tests/tier2/tc_2067_validate_uniform_mapping_format.py
+++ b/tests/tier2/tc_2067_validate_uniform_mapping_format.py
@@ -35,8 +35,11 @@ class Testcase(Testing):
         data, tty_output, rhsm_output = self.vw_start(cli='virt-who -do', exp_send=1)
         ret, fake_json = self.runcmd("cat {0}".format(json_file), self.ssh_host())
         fake_json_lines = fake_json.split('\n')
+        # BZ1933578 WONTFIX
+        if hypervisor_type == 'libvirt-local':
+            fake_json_lines = fake_json_lines[5:-6]
         for line in fake_json_lines:
-            results.setdefault('step2', []).append(line in tty_output)
+            results.setdefault('step2', []).append(line.strip() in tty_output)
 
         # case result
         self.vw_case_result(results)


### PR DESCRIPTION
In bz1933578, for local libvirt, the mapping format in debug output is different with print output json. As the bug has been closed as WONTFIX, so we should update our test case to match the local mode.

**Test Result**
```
% python3 -m pytest tests/tier2/tc_2067_validate_uniform_mapping_format.py 
========================================================= test session starts =========================================================
platform darwin -- Python 3.9.6, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/yuefliu/workspace/virtwho-ci
collected 1 item                                                                                                                      

tests/tier2/tc_2067_validate_uniform_mapping_format.py .                                                                        [100%]

============================================== 1 passed, 2 warnings in 148.07s (0:02:28) ==================
```

**And has tested with esx mode, the code will not impact other modes.**